### PR TITLE
Datenschutzerklärung: Cookies und lokale Speicherung

### DIFF
--- a/frontend/src/i18n/da/translations.json
+++ b/frontend/src/i18n/da/translations.json
@@ -1040,7 +1040,7 @@
             "title": "Nulstil løb?",
             "warning": "Advarsel: Dette løb nulstilles til ”aldrig kørt”. Uigenkaldeligt mistes: den faktiske start, alle mål- og mellemtider, alle placeringer, diskvalifikationer og tidsstraffe for dette løb.",
             "keeps": "Bevares: opstilling, baner og bådenes id'er — RaceClocker-tilknytningen forbliver gyldig, og løbet kan køres igen med det samme.",
-          "autoPull": "Den automatiske RaceClocker-hentning sættes på pause for dette løb — ellers ville næste hentning straks genindlæse de slettede resultater. Efter oprydning i RaceClocker genoptages bevidst via ”Genoptag automatisk hentning”.",
+            "autoPull": "Den automatiske RaceClocker-hentning sættes på pause for dette løb — ellers ville næste hentning straks genindlæse de slettede resultater. Efter oprydning i RaceClocker genoptages bevidst via ”Genoptag automatisk hentning”.",
             "question": "Vil du virkelig nulstille løbet?"
           },
           "error": "Der opstod en fejl ved nulstilling af løbet",
@@ -2020,9 +2020,9 @@
       },
       "indicator": {
         "now": "Nu",
-          "planned": "Planlagt {{time}}",
-          "started": "Startet {{time}}",
-          "expected": "Forventet ~{{time}}",
+        "planned": "Planlagt {{time}}",
+        "started": "Startet {{time}}",
+        "expected": "Forventet ~{{time}}",
         "state": {
           "finished": "Afsluttet",
           "preparing": "Forbereder",
@@ -3123,5 +3123,9 @@
     "team": "Hold",
     "deregistered": "Afmeldt",
     "noMatches": "Der er endnu ikke planlagt noget løb for dig."
+  },
+  "legal": {
+    "privacy": "Privatlivspolitik",
+    "privacyTitle": "Privatlivspolitik"
   }
 }

--- a/frontend/src/i18n/de/translations.json
+++ b/frontend/src/i18n/de/translations.json
@@ -1040,7 +1040,7 @@
             "title": "Lauf zurücksetzen?",
             "warning": "Achtung: Dieser Lauf wird auf „nie gefahren“ zurückgesetzt. Unwiderruflich verloren gehen: der Ist-Start, alle Ziel- und Zwischenzeiten, alle Plätze, Ausscheidungen und Zeitstrafen dieses Laufs.",
             "keeps": "Erhalten bleiben: Aufstellung, Bahnen und die Kennungen der Boote — die RaceClocker-Zuordnung bleibt gültig, der Lauf kann direkt neu gefahren werden.",
-          "autoPull": "Der automatische RaceClocker-Abruf wird für diesen Lauf pausiert — sonst spielte der nächste Abruf die gelöschten Ergebnisse sofort wieder ein. Nach dem Aufräumen in RaceClocker über „Automatik wieder aufnehmen“ bewusst fortsetzen.",
+            "autoPull": "Der automatische RaceClocker-Abruf wird für diesen Lauf pausiert — sonst spielte der nächste Abruf die gelöschten Ergebnisse sofort wieder ein. Nach dem Aufräumen in RaceClocker über „Automatik wieder aufnehmen“ bewusst fortsetzen.",
             "question": "Lauf wirklich zurücksetzen?"
           },
           "error": "Beim Zurücksetzen des Laufs ist ein Fehler aufgetreten",
@@ -1090,9 +1090,9 @@
             "activate": "Lauf aktivieren",
             "deactivate": "Lauf deaktivieren",
             "markStarted": "Läuft",
-          "finish": "Lauf beenden",
-          "finishConfirm": "Diesen Lauf jetzt beenden? Wenn die Veranstaltung automatisch weiterschaltet, werden dabei die nächsten Läufe aktiviert.",
-          "finishSuccess": "Lauf beendet",
+            "finish": "Lauf beenden",
+            "finishConfirm": "Diesen Lauf jetzt beenden? Wenn die Veranstaltung automatisch weiterschaltet, werden dabei die nächsten Läufe aktiviert.",
+            "finishSuccess": "Lauf beendet",
             "reopen": "Beenden zurücknehmen"
           }
         },
@@ -2026,9 +2026,9 @@
       },
       "indicator": {
         "now": "Jetzt",
-          "planned": "Geplant {{time}}",
-          "started": "Gestartet {{time}}",
-          "expected": "Erwartet ~{{time}}",
+        "planned": "Geplant {{time}}",
+        "started": "Gestartet {{time}}",
+        "expected": "Erwartet ~{{time}}",
         "state": {
           "finished": "Beendet",
           "preparing": "In Vorbereitung",
@@ -3129,5 +3129,9 @@
     "team": "Mannschaft",
     "deregistered": "Abgemeldet",
     "noMatches": "Für dich ist noch kein Lauf eingetragen."
+  },
+  "legal": {
+    "privacy": "Datenschutz",
+    "privacyTitle": "Datenschutzerklärung"
   }
 }

--- a/frontend/src/i18n/en/translations.json
+++ b/frontend/src/i18n/en/translations.json
@@ -1040,7 +1040,7 @@
             "title": "Reset race?",
             "warning": "Warning: This race will be reset to “never raced”. Irrevocably lost: the actual start, all finish and split times, all places, disqualifications and time penalties of this race.",
             "keeps": "Kept: line-up, lanes and the boats' identifiers — the RaceClocker mapping stays valid and the race can be raced again right away.",
-          "autoPull": "The automatic RaceClocker pull is paused for this race — otherwise the next pull would immediately re-import the deleted results. After cleaning up in RaceClocker, resume deliberately via “Resume automatic pull”.",
+            "autoPull": "The automatic RaceClocker pull is paused for this race — otherwise the next pull would immediately re-import the deleted results. After cleaning up in RaceClocker, resume deliberately via “Resume automatic pull”.",
             "question": "Really reset this race?"
           },
           "error": "An error has occurred when resetting the race",
@@ -1090,9 +1090,9 @@
             "activate": "Activate race",
             "deactivate": "Deactivate race",
             "markStarted": "Running",
-          "finish": "Finish race",
-          "finishConfirm": "Finish this race now? If the event advances automatically, this activates the next races.",
-          "finishSuccess": "Race finished",
+            "finish": "Finish race",
+            "finishConfirm": "Finish this race now? If the event advances automatically, this activates the next races.",
+            "finishSuccess": "Race finished",
             "reopen": "Undo finish"
           }
         },
@@ -2026,9 +2026,9 @@
       },
       "indicator": {
         "now": "Now",
-          "planned": "Planned {{time}}",
-          "started": "Started {{time}}",
-          "expected": "Expected ~{{time}}",
+        "planned": "Planned {{time}}",
+        "started": "Started {{time}}",
+        "expected": "Expected ~{{time}}",
         "state": {
           "finished": "Finished",
           "preparing": "Preparing",
@@ -3129,5 +3129,9 @@
     "team": "Team",
     "deregistered": "Withdrawn",
     "noMatches": "No race has been scheduled for you yet."
+  },
+  "legal": {
+    "privacy": "Privacy policy",
+    "privacyTitle": "Privacy policy"
   }
 }

--- a/frontend/src/layouts/ResultsLayout.tsx
+++ b/frontend/src/layouts/ResultsLayout.tsx
@@ -1,8 +1,11 @@
 import {Outlet} from '@tanstack/react-router'
-import {Container, Box} from '@mui/material'
+import {Container, Box, Link as MuiLink} from '@mui/material'
+import {Link} from '@tanstack/react-router'
+import {useTranslation} from 'react-i18next'
 import {useEffect} from 'react'
 
 const ResultsLayout = () => {
+    const {t} = useTranslation()
     // Die Ergebnisseite trägt Namen von Teilnehmenden und über "Mein Event" den Zustand
     // persönlicher Bedingungen. Ein Suchmaschinentreffer würde aus "wer den Link hat"
     // ein "wer den Namen sucht" machen. Der Schutz hängt bewusst am Layout und nicht an
@@ -40,6 +43,18 @@ const ResultsLayout = () => {
                     flexDirection: 'column',
                 }}>
                 <Outlet />
+            </Box>
+            {/* Dezenter Fußbereich: die Datenschutzerklärung muss von der öffentlichen
+                Seite aus erreichbar sein (Informationspflicht), ohne die Anzeige zu stören. */}
+            <Box component="footer" sx={{py: 2}}>
+                <MuiLink
+                    component={Link}
+                    to="/datenschutz"
+                    variant="caption"
+                    color="text.secondary"
+                    underline="hover">
+                    {t('legal.privacy')}
+                </MuiLink>
             </Box>
         </Container>
     )

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -198,6 +198,13 @@ const RootLayout = () => {
                                     )}
                                 </Stack>
                             )}
+                            <Box sx={{display: 'flex', justifyContent: 'center', mt: 1}}>
+                                <Link to="/datenschutz">
+                                    <Typography variant="caption" color="text.secondary">
+                                        {t('legal.privacy')}
+                                    </Typography>
+                                </Link>
+                            </Box>
                         </Stack>
                     </Box>
                 </Box>

--- a/frontend/src/pages/DatenschutzPage.tsx
+++ b/frontend/src/pages/DatenschutzPage.tsx
@@ -1,0 +1,103 @@
+import {Container, Divider, Stack, Typography} from '@mui/material'
+import {useTranslation} from 'react-i18next'
+import {useDocumentTitle} from '@utils/useDocumentTitle.ts'
+
+/**
+ * Öffentliche Datenschutzerklärung. Der Fließtext bleibt bewusst deutsch und hart kodiert:
+ * Er ist die rechtsverbindliche Fassung und soll sich nicht je Sprachwahl unterscheiden —
+ * nur Seitentitel und Verweise laufen über i18n. Die Seite ist so geschnitten, dass weitere
+ * Abschnitte (Verantwortlicher, Weitergabe an die Zeitnahme, Veröffentlichung von
+ * Ergebnissen, Betroffenenrechte, …) als zusätzliche <section>-Blöcke davor oder danach
+ * ergänzt werden können.
+ */
+const DatenschutzPage = () => {
+    const {t} = useTranslation()
+    useDocumentTitle(t('legal.privacyTitle'))
+
+    return (
+        <Container maxWidth="md" sx={{py: {xs: 3, sm: 6}}}>
+            <Stack spacing={3}>
+                <Typography variant="h1">{t('legal.privacyTitle')}</Typography>
+
+                {/* Abschnitt: Cookies und lokale Speicherung (Wortlaut vom 13.08.2026) */}
+                <section>
+                    <Typography variant="h2" gutterBottom>
+                        Cookies und lokale Speicherung im Browser
+                    </Typography>
+                    <Stack spacing={2}>
+                        <Typography>
+                            Diese Anwendung verwendet <strong>keine Cookies oder vergleichbare
+                            Techniken zu Werbe-, Tracking- oder Analysezwecken</strong> und bindet
+                            keine Dienste von Drittanbietern ein, die solche Techniken einsetzen.
+                        </Typography>
+                        <Typography>
+                            Zur Bereitstellung der von Ihnen angeforderten Funktionen speichert die
+                            Anwendung technisch erforderliche Informationen im lokalen Speicher
+                            Ihres Browsers (localStorage/sessionStorage) sowie im
+                            Anwendungs-Cache. Diese Speicherung ist nach § 25 Abs. 2 Nr. 2 TDDDG
+                            einwilligungsfrei, da sie unbedingt erforderlich ist, um den von Ihnen
+                            ausdrücklich gewünschten Dienst zur Verfügung zu stellen. Ein
+                            Einwilligungsbanner ist daher nicht erforderlich. Im Einzelnen:
+                        </Typography>
+
+                        <Typography variant="h3">
+                            Anmeldung (nur bei aktiver Nutzung eines Kontos)
+                        </Typography>
+                        <Typography>
+                            <em>Sitzungs-Token</em> („session.admin“ bzw. „session.app“): hält Ihre
+                            Anmeldung aufrecht. Der Token verfällt serverseitig spätestens 6 Stunden
+                            nach der letzten Aktivität und wird beim Abmelden gelöscht. In der
+                            Helfer-App wird zusätzlich Ihre Berechtigungsstufe gespeichert
+                            („session.user“), damit die App nach einem Neustart ohne Netzverbindung
+                            funktionsfähig bleibt.
+                        </Typography>
+
+                        <Typography variant="h3">
+                            Persönliches Event-Dashboard „Mein Event“ (nur nach Scan Ihres
+                            Teilnehmerbands)
+                        </Typography>
+                        <Typography>
+                            <em>Zugangscode des Teilnehmerbands</em> („my_event_codes“): wird
+                            ausschließlich auf Ihrem Gerät gespeichert, wenn Sie den QR-Code Ihres
+                            Bands scannen, damit Ihr persönlicher Zeitplan beim nächsten Aufruf ohne
+                            erneuten Scan erscheint. Sie können den Eintrag jederzeit in der Ansicht
+                            selbst entfernen.
+                        </Typography>
+
+                        <Typography variant="h3">
+                            Anzeige-Einstellungen (gerätebezogen, ohne Personenbezug)
+                        </Typography>
+                        <Typography>
+                            Darstellungs- und Filtereinstellungen, z.&nbsp;B. Kurz-/Langform von
+                            Wettkampfnamen, Filter und Schriftgröße des Schiedsrichter-Dashboards,
+                            Kameraauswahl des QR-Scanners, Fensterverhalten des Zeitplans sowie das
+                            Ausblenden einmal geschlossener Hinweise. Diese Werte enthalten keine
+                            personenbezogenen Daten und verbleiben ausschließlich auf Ihrem Gerät.
+                        </Typography>
+
+                        <Typography variant="h3">Offline-Fähigkeit der Helfer-App</Typography>
+                        <Typography>
+                            Die als App installierbare Helferansicht (PWA) legt über einen Service
+                            Worker Programmdateien und – nur auf dafür eingerichteten Geräten – den
+                            zuletzt geladenen Datenstand im Browser-Cache ab, damit die Anzeige bei
+                            kurzzeitigem Verbindungsverlust am Veranstaltungsgelände nutzbar bleibt.
+                        </Typography>
+
+                        <Divider />
+
+                        <Typography>
+                            Alle genannten Informationen werden ausschließlich durch diese Anwendung
+                            selbst („First Party“) gespeichert und gelesen; eine Weitergabe an
+                            Dritte findet nicht statt. Sie können die gespeicherten Daten jederzeit
+                            über die Einstellungen Ihres Browsers einsehen und löschen; die
+                            Anwendung bleibt danach nutzbar, gegebenenfalls ist eine erneute
+                            Anmeldung bzw. ein erneuter Scan erforderlich.
+                        </Typography>
+                    </Stack>
+                </section>
+            </Stack>
+        </Container>
+    )
+}
+
+export default DatenschutzPage

--- a/frontend/src/pages/app/AppLoginPage.tsx
+++ b/frontend/src/pages/app/AppLoginPage.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react'
+import {Link} from '@tanstack/react-router'
 import {useTranslation} from 'react-i18next'
 import {FormContainer, useForm} from 'react-hook-form-mui'
 import {
@@ -138,6 +139,11 @@ const AppLoginPage = () => {
                     )}
                 </Alert>
             )}
+            <Link to="/datenschutz">
+                <Typography variant="caption" color="text.secondary" sx={{mt: 3}}>
+                    {t('legal.privacy')}
+                </Typography>
+            </Link>
         </Box>
     )
 }

--- a/frontend/src/pages/user/LoginPage.tsx
+++ b/frontend/src/pages/user/LoginPage.tsx
@@ -68,6 +68,13 @@ const LoginPage = () => {
                     <SubmitButton submitting={submitting}>{t('user.login.submit')}</SubmitButton>
                 </Stack>
             </FormContainer>
+            <Box sx={{display: 'flex', justifyContent: 'center', mt: 3}}>
+                <Link to="/datenschutz">
+                    <Typography variant="caption" color="text.secondary">
+                        {t('legal.privacy')}
+                    </Typography>
+                </Link>
+            </Box>
         </SimpleFormLayout>
     )
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -60,6 +60,7 @@ import ResultsQrCodePage from './pages/results/ResultsQrCodePage.tsx'
 import ResultsLayout from './layouts/ResultsLayout.tsx'
 import AdministrationPage from './pages/AdministrationPage.tsx'
 import ChallengePage from './pages/challenge/ChallengePage.tsx'
+import DatenschutzPage from './pages/DatenschutzPage.tsx'
 
 const checkAuth = (context: User, location: ParsedLocation, privilege?: Privilege) => {
     if (!context.loggedIn) {
@@ -521,6 +522,14 @@ export const challengeRoute = createRoute({
 // Öffentliche Route ohne App-Layout: fest montierte Athletenbildschirme und
 // Athleten-Handys brauchen weder Kopfleiste noch Seitenleiste noch Anmeldung.
 // Bestands-URL der alten Athleten-Anzeige — leitet auf das erste Board um.
+// Öffentliche Datenschutzerklärung — bewusst ohne Anmeldung erreichbar, verlinkt von
+// Ergebnisseite und Login-Seiten.
+export const datenschutzRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: 'datenschutz',
+    component: () => <DatenschutzPage />,
+})
+
 export const athleteBoardRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: 'board/$eventId',
@@ -576,6 +585,7 @@ const routeTree = rootRoute.addChildren([
     mobileRoute.addChildren([challengeRoute]),
     athleteBoardRoute,
     boardDisplayRoute,
+    datenschutzRoute,
 ])
 
 const basepath = document.getElementById('ready2race-root')!.dataset.basepath


### PR DESCRIPTION
Bewusst als eigener, kleiner PR neben #100, damit er unabhängig gemergt (oder verworfen) werden kann.

## Ausgangslage
Wie abgesprochen setzt die Anwendung auf **localStorage statt Cookies** — es werden keine Cookies gesetzt. Gespeichert wird ausschließlich technisch Erforderliches im Browser: Sitzungs-Token in `sessionStorage`/`localStorage`, „Mein Event“-Zugangscodes, gerätelokale Anzeige-Einstellungen und PWA-Caches. Tracking- oder Analyse-Dienste gibt es nicht. Dieser PR zieht daraus die Konsequenz für die Datenschutz-Seite.

## Historie: das war von Anfang an so angelegt
Der Browser-Storage-Ansatz ist keine neue Idee dieses PRs, sondern die konsequente Fortführung der bestehenden Architektur:

- **Header-basierte Sessions mit Token im `sessionStorage`** sind seit Juni 2025 der Sessionmechanismus der Anwendung — ein Cookie gab es zu keinem Zeitpunkt.
- Die **QR-/Helfer-App** merkt sich seit ihrer Einführung (Juli 2025) die Kamerawahl gerätelokal in `localStorage`.
- Auch die öffentliche QR-Einstiegsseite (`/results/$qrCode`, seit August 2025) war von Beginn an so geschnitten, dass der Code über die Adresse hereinkommt und nichts Sensibles zurückbleibt.

Die jüngeren Ergänzungen führen genau diese Logik fort: Der Admin-Token wanderte von `sessionStorage` nach `localStorage` mit gleitendem 6-Stunden-Fenster (Login überlebt den Tab-Wechsel), die Helfer-App hält Session und Datenstand für den Offline-Start vor (PWA), „Mein Event“ merkt sich gescannte Bandcodes bewusst **im Gerätespeicher statt in der URL** (ein weitergereichter Link öffnet kein fremdes Dashboard), und Anzeige-Einstellungen bleiben rein gerätelokal. Die Grundentscheidung — alles First-Party im Browser, nichts per Cookie, nichts an Dritte — war also durchdacht und trägt auch datenschutzrechtlich; dieser PR macht sie nur nach außen sichtbar.

## Braucht es überhaupt eine Erklärung? Die Überlegungen im Einzelnen

1. **Kein Einwilligungsbanner nötig.** § 25 TDDDG ist technologieneutral — er erfasst Cookies und localStorage gleichermaßen; die Technikwahl allein befreit also nicht. Entscheidend ist § 25 Abs. 2 Nr. 2 TDDDG: Die Speicherung ist einwilligungsfrei, weil sie unbedingt erforderlich ist, um den ausdrücklich gewünschten Dienst bereitzustellen (Login halten, gescannten Bandcode merken, Anzeige-Einstellungen, Offline-Fähigkeit der Helfer-App). Ein Banner wäre hier sogar irreführend.

2. **Möglicherweise auch keine Pflicht zu einer eigenen Speicher-Erklärung.** Die Informationspflicht des § 25 Abs. 1 TDDDG hängt an der Einwilligung — für nach Abs. 2 ausgenommene Speicherung greift sie nicht. Und die DSGVO-Informationspflichten (Art. 13) knüpfen an die Verarbeitung personenbezogener Daten an, nicht an das Speichermedium: Rein gerätelokale Werte (Anzeige-Einstellungen, PWA-Cache) verlassen das Gerät nie und haben keinen Personenbezug — insoweit findet gar keine Verarbeitung durch den Betreiber statt, über die zu informieren wäre. Da die Anwendung cookiefrei ist, entfällt auch der klassische „Cookie-Hinweis“ als eigene Kategorie.

3. **Was pflichtig bleibt, ist nicht der localStorage.** Bei Sitzungs-Token und Bandcodes gibt es serverseitige Verarbeitung (Konto-Session, Abruf des persönlichen Zeitplans). Darüber ist nach Art. 13 DSGVO zu informieren — aber das betrifft die Verarbeitung als solche (Konten, Teilnehmerdaten) und gehört in die allgemeine Datenschutzerklärung des jeweiligen Veranstalters/Betreibers, unabhängig davon, wo der Token im Browser liegt.

**Fazit:** Cookiefreie Architektur plus Beschränkung auf technisch Erforderliches heißt: sicher kein Banner, und nach dieser Lesart auch keine zwingende eigene Speicher-Erklärung. Die Seite in diesem PR ist daher als freiwillige Transparenz zu verstehen: Sie dokumentiert den Ist-Zustand, beantwortet die naheliegende Nutzerfrage „Warum gibt es hier kein Cookie-Banner?“ und bietet einen Ort, an dem Betreiber die ohnehin nötigen Abschnitte (Verantwortlicher, Weitergabe an die Zeitnahme, Ergebnisveröffentlichung, Betroffenenrechte) ergänzen können. Ob ihr sie so übernehmen wollt, ist eine Produktentscheidung — der PR erhebt keinen Rechtsberatungsanspruch.

## Inhalt
- Neue öffentliche Seite **`/datenschutz`** (`DatenschutzPage.tsx`) mit dem Abschnitt „Cookies und lokale Speicherung im Browser“: listet alle gespeicherten Einträge, Zweck und Löschweg auf. Der Fließtext ist bewusst deutsch und hart kodiert (rechtsverbindliche Fassung); nur Titel/Verweise laufen über i18n (`legal.privacy`, de/en/da). Weitere Abschnitte können als zusätzliche `<section>`-Blöcke ergänzt werden.
- Verweise: Footer der öffentlichen Ergebnisansicht (`ResultsLayout`), Fußbereich des Hauptlayouts (`RootLayout`), Admin-Login und Helfer-App-Login.

## Hinweis
Sollte künftig ein Analyse-/Statistik-Werkzeug eingebunden werden, kippt die Bewertung: Dann ist die Speicherung nicht mehr unbedingt erforderlich, eine Einwilligung (Banner) wird nötig und die Seite ist anzupassen — egal ob per Cookie oder localStorage.

## Teststand
1044 Frontend-Tests grün, Build sauber; Seite und alle vier Verweise im Browser geprüft (Landing, `/results`, `/login`, `/app`).
