### PR TITLE
Rundmail an alle Melder einer Veranstaltung

### DIFF
--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/boundary/RegistrationMailService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/boundary/RegistrationMailService.kt
@@ -1,0 +1,130 @@
+package de.lambda9.ready2race.backend.app.eventRegistration.boundary
+
+import de.lambda9.ready2race.backend.app.App
+import de.lambda9.ready2race.backend.app.email.boundary.EmailService
+import de.lambda9.ready2race.backend.app.email.entity.EmailAttachment
+import de.lambda9.ready2race.backend.app.email.entity.EmailBody
+import de.lambda9.ready2race.backend.app.email.entity.EmailContent
+import de.lambda9.ready2race.backend.app.email.entity.EmailTemplatePlaceholder
+import de.lambda9.ready2race.backend.app.event.control.EventRepo
+import de.lambda9.ready2race.backend.app.eventRegistration.control.RegistrationMailRepo
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.EventRegistrationError
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailRecipientDto
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailRequest
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailResultDto
+import de.lambda9.ready2race.backend.calls.responses.ApiResponse
+import de.lambda9.ready2race.backend.validation.emailPattern
+import de.lambda9.tailwind.core.KIO
+import de.lambda9.tailwind.core.extensions.kio.onNullFail
+import de.lambda9.tailwind.core.extensions.kio.orDie
+import java.util.UUID
+import kotlin.time.Duration.Companion.days
+import kotlin.time.DurationUnit
+
+/**
+ * Die Rundmail an alle, die zu einer Veranstaltung gemeldet haben.
+ *
+ * Bewusst neben [EventRegistrationService] und nicht darin: die Meldelogik dort ist mit über 1200
+ * Zeilen schon reichlich, und mit dem Meldevorgang selbst hat das Anschreiben nichts zu tun.
+ */
+object RegistrationMailService {
+
+    /**
+     * Rundmails überleben das Senden um eine Woche, statt wie sonst sofort von
+     * `EmailService.deleteSent` geholt zu werden: geht am Regattatag etwas an den falschen Kreis
+     * raus, muss am Tag danach noch nachvollziehbar sein, was an wen ging.
+     */
+    private val keepAfterSending = 7.days
+
+    val KEEP_AFTER_SENDING_SECONDS = keepAfterSending.toLong(DurationUnit.SECONDS)
+
+    fun getRecipients(eventId: UUID): App<Nothing, ApiResponse.ListDto<RegistrationMailRecipientDto>> =
+        RegistrationMailRepo.getRecipients(eventId).orDie().map { ApiResponse.ListDto(it) }
+
+    fun send(
+        eventId: UUID,
+        request: RegistrationMailRequest,
+        attachments: List<EmailAttachment>,
+        userId: UUID,
+    ): App<EventRegistrationError, ApiResponse.Dto<RegistrationMailResultDto>> = KIO.comprehension {
+
+        val event = !EventRepo.get(eventId).orDie().onNullFail { EventRegistrationError.EventNotFound }
+
+        val known = !RegistrationMailRepo.getRecipients(eventId).orDie().map { it.associateBy { r -> r.registrationId } }
+
+        val selected = request.registrationIds.distinct().map { id ->
+            val recipient = !KIO.failOnNull(known[id]) { EventRegistrationError.MailRecipientNotFound(id) }
+            // Der Dialog bietet Meldungen ohne Nutzer gar nicht erst an. Kommt trotzdem eine
+            // herein, ist die Liste veraltet - dann lieber gar nichts verschicken, als eine
+            // Rundmail rausgehen zu lassen, in der still jemand fehlt.
+            !KIO.failOn(recipient.email == null) { EventRegistrationError.MailRecipientWithoutUser(id) }
+            recipient
+        }
+
+        val additional = request.additionalAddresses.map { raw ->
+            val address = raw.trim()
+            !KIO.failOn(!emailPattern.matches(address)) { EventRegistrationError.MailAddressInvalid(raw) }
+            address
+        }
+
+        // Eine Adresse bekommt genau eine Mail. Steht sie schon als Melder in der Liste, gewinnt
+        // der Melder - nur seine Mail kennt Namen und Verein für die Platzhalter.
+        val takenAddresses = selected.map { it.email!!.lowercase() }.toMutableSet()
+        val extraAddresses = additional.filter { takenAddresses.add(it.lowercase()) }
+
+        !KIO.failOn(selected.isEmpty() && extraAddresses.isEmpty()) { EventRegistrationError.MailWithoutRecipients }
+
+        selected.forEach { recipient ->
+            !enqueue(
+                address = recipient.email!!,
+                request = request,
+                eventName = event.name!!,
+                recipientName = recipient.name ?: "",
+                clubName = recipient.clubName,
+                attachments = attachments,
+                userId = userId,
+            )
+        }
+
+        extraAddresses.forEach { address ->
+            !enqueue(
+                address = address,
+                request = request,
+                eventName = event.name!!,
+                recipientName = "",
+                clubName = "",
+                attachments = attachments,
+                userId = userId,
+            )
+        }
+
+        KIO.ok(ApiResponse.Dto(RegistrationMailResultDto(enqueued = selected.size + extraAddresses.size)))
+    }
+
+    private fun enqueue(
+        address: String,
+        request: RegistrationMailRequest,
+        eventName: String,
+        recipientName: String,
+        clubName: String,
+        attachments: List<EmailAttachment>,
+        userId: UUID,
+    ): App<Nothing, UUID> {
+
+        fun fill(text: String) = text
+            .replace(EmailTemplatePlaceholder.RECIPIENT.key, recipientName)
+            .replace(EmailTemplatePlaceholder.CLUB.key, clubName)
+            .replace(EmailTemplatePlaceholder.EVENT.key, eventName)
+
+        return EmailService.enqueue(
+            recipient = address,
+            content = EmailContent(
+                subject = fill(request.subject),
+                body = EmailBody.Text(fill(request.body)),
+            ),
+            attachments = attachments,
+            keepAfterSending = keepAfterSending,
+            appUserId = userId,
+        )
+    }
+}

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/boundary/eventRegistration.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/boundary/eventRegistration.kt
@@ -1,17 +1,26 @@
 package de.lambda9.ready2race.backend.app.eventRegistration.boundary
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import de.lambda9.ready2race.backend.app.auth.entity.Privilege
+import de.lambda9.ready2race.backend.app.email.entity.EmailAttachment
 import de.lambda9.ready2race.backend.app.eventRegistration.entity.EventRegistrationUpsertDto
 import de.lambda9.ready2race.backend.app.eventRegistration.entity.EventRegistrationViewSort
 import de.lambda9.ready2race.backend.app.eventRegistration.entity.ParticipantRegisterRequest
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailRequest
 import de.lambda9.ready2race.backend.app.invoice.boundary.InvoiceService
 import de.lambda9.ready2race.backend.app.invoice.entity.InvoiceForEventRegistrationSort
 import de.lambda9.ready2race.backend.calls.requests.*
 import de.lambda9.ready2race.backend.calls.responses.respondComprehension
+import de.lambda9.ready2race.backend.calls.serialization.jsonMapper
 import de.lambda9.ready2race.backend.parsing.Parser.Companion.boolean
 import de.lambda9.ready2race.backend.parsing.Parser.Companion.uuid
+import de.lambda9.ready2race.backend.validation.ValidationResult
+import de.lambda9.tailwind.core.KIO
 import de.lambda9.tailwind.core.extensions.kio.onNullDefault
+import io.ktor.http.content.*
+import io.ktor.server.request.*
 import io.ktor.server.routing.*
+import io.ktor.utils.io.*
 
 fun Route.eventRegistration() {
 
@@ -49,6 +58,63 @@ fun Route.eventRegistration() {
                     val params = !pagination<InvoiceForEventRegistrationSort>()
                     InvoiceService.pageForRegistration(id, params, user, scope)
                 }
+            }
+        }
+
+        get("/mailRecipients") {
+            call.respondComprehension {
+                !authenticate(Privilege.UpdateEventGlobal)
+                val eventId = !pathParam("eventId", uuid)
+                RegistrationMailService.getRecipients(eventId)
+            }
+        }
+
+        post("/mail") {
+            call.respondComprehension {
+                val user = !authenticate(Privilege.UpdateEventGlobal)
+                val eventId = !pathParam("eventId", uuid)
+
+                // Anhänge und Rumpf kommen gemeinsam als Multipart herein - wie beim
+                // Vereins-Import, nur dass hier mehrere Dateien erlaubt sind.
+                val multiPartData = receiveMultipart()
+                val attachments = mutableListOf<EmailAttachment>()
+                var request: RegistrationMailRequest? = null
+
+                var done = false
+                while (!done) {
+                    val part = multiPartData.readPart()
+                    if (part == null) {
+                        done = true
+                    } else {
+                        when (part) {
+                            is PartData.FileItem -> {
+                                attachments.add(
+                                    EmailAttachment(
+                                        name = part.originalFileName!!,
+                                        data = part.provider().toByteArray(),
+                                    )
+                                )
+                            }
+
+                            is PartData.FormItem -> {
+                                if (part.name == "request") {
+                                    request = jsonMapper.readValue<RegistrationMailRequest>(part.value)
+                                }
+                            }
+
+                            else -> {}
+                        }
+                        part.dispose()
+                    }
+                }
+
+                val req = !KIO.failOnNull(request) { RequestError.BodyMissing(RegistrationMailRequest.example) }
+                val validation = req.validate()
+                !KIO.failOn(validation is ValidationResult.Invalid) {
+                    RequestError.BodyValidationFailed(validation as ValidationResult.Invalid)
+                }
+
+                RegistrationMailService.send(eventId, req, attachments, user.id!!)
             }
         }
 

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/control/RegistrationMailRepo.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/control/RegistrationMailRepo.kt
@@ -1,0 +1,48 @@
+package de.lambda9.ready2race.backend.app.eventRegistration.control
+
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailRecipientDto
+import de.lambda9.ready2race.backend.database.generated.tables.references.APP_USER
+import de.lambda9.ready2race.backend.database.generated.tables.references.CLUB
+import de.lambda9.ready2race.backend.database.generated.tables.references.EVENT_REGISTRATION
+import de.lambda9.tailwind.jooq.JIO
+import de.lambda9.tailwind.jooq.Jooq
+import java.util.UUID
+
+object RegistrationMailRepo {
+
+    /**
+     * Die Melder einer Veranstaltung: je Meldung der Verein und die Person, die sie abgeschickt
+     * hat.
+     *
+     * Der Weg zur Person führt über `event_registration.created_by` und nicht über den Verein -
+     * ein Verein kann Nutzer haben, die zu dieser Veranstaltung nichts gemeldet haben, und meldet
+     * zu mehreren Veranstaltungen. Der Join auf app_user ist deshalb ein LEFT JOIN: gelöschte
+     * Ersteller lassen die Meldung stehen und nur die Adresse fehlen.
+     */
+    fun getRecipients(eventId: UUID): JIO<List<RegistrationMailRecipientDto>> = Jooq.query {
+        select(
+            EVENT_REGISTRATION.ID,
+            CLUB.ID,
+            CLUB.NAME,
+            APP_USER.FIRSTNAME,
+            APP_USER.LASTNAME,
+            APP_USER.EMAIL,
+        )
+            .from(EVENT_REGISTRATION)
+            .join(CLUB).on(CLUB.ID.eq(EVENT_REGISTRATION.CLUB))
+            .leftJoin(APP_USER).on(APP_USER.ID.eq(EVENT_REGISTRATION.CREATED_BY))
+            .where(EVENT_REGISTRATION.EVENT.eq(eventId))
+            .orderBy(CLUB.NAME.asc())
+            .fetch { record ->
+                val email = record[APP_USER.EMAIL]
+                RegistrationMailRecipientDto(
+                    registrationId = record[EVENT_REGISTRATION.ID]!!,
+                    clubId = record[CLUB.ID]!!,
+                    clubName = record[CLUB.NAME]!!,
+                    // Name und Adresse hängen am selben Nutzer: fehlt er, fehlen beide.
+                    name = email?.let { "${record[APP_USER.FIRSTNAME]} ${record[APP_USER.LASTNAME]}" },
+                    email = email,
+                )
+            }
+    }
+}

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/EventRegistrationError.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/EventRegistrationError.kt
@@ -15,6 +15,11 @@ sealed interface EventRegistrationError : ServiceError {
     data object SelfRegistrationOnlyForSingleCompetitions : EventRegistrationError
     data object OnlyAvailableForClubUsers : EventRegistrationError
     data object DocumentsAlreadyAccepted : EventRegistrationError
+    data object MailWithoutRecipients : EventRegistrationError
+
+    data class MailRecipientNotFound(val registrationId: UUID) : EventRegistrationError
+    data class MailRecipientWithoutUser(val registrationId: UUID) : EventRegistrationError
+    data class MailAddressInvalid(val address: String) : EventRegistrationError
 
     data class InvalidRegistration(val msg: String) : EventRegistrationError
     data class UpsertParticipantNotFound(val id: UUID) : EventRegistrationError
@@ -136,6 +141,28 @@ sealed interface EventRegistrationError : ServiceError {
         DocumentsAlreadyAccepted -> ApiError(
             status = HttpStatusCode.Conflict,
             message = "The event documents have already been accepted"
+        )
+
+        MailWithoutRecipients -> ApiError(
+            status = HttpStatusCode.BadRequest,
+            message = "No recipients selected"
+        )
+
+        is MailRecipientNotFound -> ApiError(
+            status = HttpStatusCode.BadRequest,
+            message = "Registration with id: $registrationId does not belong to this event"
+        )
+
+        // Passiert, wenn der Dialog offen stand, während der Nutzer gelöscht wurde. Lieber der
+        // ganze Versand abgelehnt als eine Rundmail, die still einen Verein auslässt.
+        is MailRecipientWithoutUser -> ApiError(
+            status = HttpStatusCode.Conflict,
+            message = "Registration with id: $registrationId has no user to send to"
+        )
+
+        is MailAddressInvalid -> ApiError(
+            status = HttpStatusCode.BadRequest,
+            message = "Not a usable email address: $address"
         )
     }
 }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailRecipientDto.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailRecipientDto.kt
@@ -1,0 +1,19 @@
+package de.lambda9.ready2race.backend.app.eventRegistration.entity
+
+import java.util.UUID
+
+/**
+ * Ein Melder der Veranstaltung, so wie ihn der Rundmail-Dialog zur Auswahl anbietet.
+ *
+ * [name] und [email] sind null, wenn der Nutzer, der die Meldung abgeschickt hat, inzwischen
+ * gelöscht ist (`event_registration.created_by` steht per `on delete set null` auf NULL). Die
+ * Meldung verschwindet dadurch nicht - der Verein muss in der Liste sichtbar bleiben, sonst
+ * bemerkt niemand, dass er die Rundmail nicht bekommt.
+ */
+data class RegistrationMailRecipientDto(
+    val registrationId: UUID,
+    val clubId: UUID,
+    val clubName: String,
+    val name: String?,
+    val email: String?,
+)

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailRequest.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailRequest.kt
@@ -1,0 +1,40 @@
+package de.lambda9.ready2race.backend.app.eventRegistration.entity
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import de.lambda9.ready2race.backend.validation.Validatable
+import de.lambda9.ready2race.backend.validation.ValidationResult
+import de.lambda9.ready2race.backend.validation.validate
+import de.lambda9.ready2race.backend.validation.validators.StringValidators.notBlank
+import java.util.UUID
+
+/**
+ * Die Rundmail, wie sie im Dialog getippt wurde. [subject] und [body] dürfen die Platzhalter
+ * `##recipient##`, `##club##` und `##event##` enthalten; sie werden je Empfänger ersetzt.
+ *
+ * [registrationIds] sind die angehakten Meldungen, [additionalAddresses] die von Hand ergänzten
+ * Adressen. Die Anhänge kommen als eigene Teile der Multipart-Anfrage und stehen deshalb nicht
+ * hier.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RegistrationMailRequest(
+    val subject: String,
+    val body: String,
+    val registrationIds: List<UUID>,
+    val additionalAddresses: List<String>,
+) : Validatable {
+    override fun validate(): ValidationResult =
+        ValidationResult.allOf(
+            this::subject validate notBlank,
+            this::body validate notBlank,
+        )
+
+    companion object {
+        val example
+            get() = RegistrationMailRequest(
+                subject = "Hinweise zum Regattatag",
+                body = "Moin ##recipient##,\n\nbitte denkt an die Waage.",
+                registrationIds = emptyList(),
+                additionalAddresses = emptyList(),
+            )
+    }
+}

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailResultDto.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/entity/RegistrationMailResultDto.kt
@@ -1,0 +1,9 @@
+package de.lambda9.ready2race.backend.app.eventRegistration.entity
+
+/**
+ * [enqueued] ist die Zahl der tatsächlich eingereihten Mails - nach dem Zusammenfallen von
+ * Adressen also nicht zwangsläufig so viele, wie der Dialog abgeschickt hat.
+ */
+data class RegistrationMailResultDto(
+    val enqueued: Int,
+)

--- a/backend/src/main/resources/openapi/documentation.yaml
+++ b/backend/src/main/resources/openapi/documentation.yaml
@@ -4037,6 +4037,70 @@ paths:
         500:
           $ref: '#/components/responses/500'
 
+  /event/{eventId}/eventRegistration/mailRecipients:
+    parameters:
+      - $ref: '#/components/parameters/eventId'
+    get:
+      operationId: getRegistrationMailRecipients
+      responses:
+        200:
+          description: The registrants of the event, as offered for selection in the bulk mail dialog
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistrationMailRecipientDto'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        500:
+          $ref: '#/components/responses/500'
+
+  /event/{eventId}/eventRegistration/mail:
+    parameters:
+      - $ref: '#/components/parameters/eventId'
+    post:
+      operationId: sendRegistrationMail
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - request
+              properties:
+                request:
+                  $ref: '#/components/schemas/RegistrationMailRequest'
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        200:
+          description: The mails have been enqueued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistrationMailResultDto'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        409:
+          $ref: '#/components/responses/409'
+        422:
+          $ref: '#/components/responses/422'
+        500:
+          $ref: '#/components/responses/500'
+
   /event/{eventId}/registrationTemplate:
     parameters:
       - $ref: '#/components/parameters/eventId'
@@ -10929,6 +10993,59 @@ components:
           type: number
         eventDocumentsOfficiallyAccepted:
           type: boolean
+
+    RegistrationMailRecipientDto:
+      type: object
+      required:
+        - registrationId
+        - clubId
+        - clubName
+      properties:
+        registrationId:
+          type: string
+          format: uuid
+        clubId:
+          type: string
+          format: uuid
+        clubName:
+          type: string
+        # Fehlen name und email, ist der Nutzer geloescht, der die Meldung abgeschickt hat.
+        # Die Zeile bleibt in der Liste, laesst sich aber nicht anwaehlen.
+        name:
+          type: string
+        email:
+          type: string
+
+    RegistrationMailRequest:
+      type: object
+      required:
+        - subject
+        - body
+        - registrationIds
+        - additionalAddresses
+      properties:
+        # subject und body duerfen ##recipient##, ##club## und ##event## enthalten.
+        subject:
+          type: string
+        body:
+          type: string
+        registrationIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        additionalAddresses:
+          type: array
+          items:
+            type: string
+
+    RegistrationMailResultDto:
+      type: object
+      required:
+        - enqueued
+      properties:
+        enqueued:
+          type: number
 
     CreateEventRequest:
       type: object

--- a/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/RegistrationMailTest.kt
+++ b/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/eventRegistration/RegistrationMailTest.kt
@@ -1,0 +1,333 @@
+package de.lambda9.ready2race.backend.app.eventRegistration
+
+import de.lambda9.ready2race.backend.app.JEnv
+import de.lambda9.ready2race.backend.app.club.CHAIN_SEED_TIME
+import de.lambda9.ready2race.backend.app.club.seedClub
+import de.lambda9.ready2race.backend.app.email.entity.EmailAttachment
+import de.lambda9.ready2race.backend.app.eventRegistration.boundary.RegistrationMailService
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.EventRegistrationError
+import de.lambda9.ready2race.backend.app.eventRegistration.entity.RegistrationMailRequest
+import de.lambda9.ready2race.backend.database.generated.tables.records.AppUserRecord
+import de.lambda9.ready2race.backend.database.generated.tables.records.EventRecord
+import de.lambda9.ready2race.backend.database.generated.tables.records.EventRegistrationRecord
+import de.lambda9.ready2race.backend.database.generated.tables.references.APP_USER
+import de.lambda9.ready2race.backend.database.generated.tables.references.EMAIL
+import de.lambda9.ready2race.backend.database.generated.tables.references.EMAIL_ATTACHMENT
+import de.lambda9.ready2race.backend.database.generated.tables.references.EVENT
+import de.lambda9.ready2race.backend.database.generated.tables.references.EVENT_REGISTRATION
+import de.lambda9.ready2race.backend.database.insert
+import de.lambda9.ready2race.testing.kio.TestComprehensionScope
+import de.lambda9.ready2race.testing.testComprehension
+import de.lambda9.tailwind.jooq.Jooq
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Die Rundmail an die Melder gegen ein echtes Postgres.
+ *
+ * Zwei Dinge lassen sich ohne Datenbank nicht festhalten und gehen genau hier schief: der
+ * Empfängerkreis hängt an `event_registration.created_by` (ein `on delete set null` macht daraus
+ * jederzeit NULL, ohne dass die Meldung verschwindet), und der Versand legt je Empfänger eine
+ * eigene Zeile in `email` samt kopierter Anhänge an - eine Schleife, die man leicht so baut, dass
+ * alle Mails denselben Text oder nur die letzte einen Anhang bekommt.
+ *
+ * Die Vorrichtung ist absichtlich zweiveranstaltungig: dieselben Vereine und derselbe Nutzer
+ * melden auch zu einer zweiten Regatta. Wer den Join über den Verein statt über die Meldung führt,
+ * besteht alle Einzelprüfungen und schreibt am Regattatag trotzdem die halbe Nachbarregatta an.
+ */
+class RegistrationMailTest {
+
+    private val kielEmail = "kiel@example.org"
+    private val flensburgEmail = "flensburg@example.org"
+
+    private data class SeededMailEvent(
+        val eventId: UUID,
+        val otherEventId: UUID,
+        val kielRegistrationId: UUID,
+        val flensburgRegistrationId: UUID,
+        val rostockRegistrationId: UUID,
+    )
+
+    private fun TestComprehensionScope<JEnv>.seedUser(email: String, firstname: String, lastname: String): UUID {
+        val id = UUID.randomUUID()
+        !APP_USER.insert(
+            AppUserRecord(
+                id = id,
+                email = email,
+                password = "x",
+                firstname = firstname,
+                lastname = lastname,
+                language = "de",
+                createdAt = CHAIN_SEED_TIME,
+                updatedAt = CHAIN_SEED_TIME,
+            )
+        )
+        return id
+    }
+
+    private fun TestComprehensionScope<JEnv>.seedRegistration(eventId: UUID, clubId: UUID, createdBy: UUID?): UUID {
+        val id = UUID.randomUUID()
+        !EVENT_REGISTRATION.insert(
+            EventRegistrationRecord(
+                id = id,
+                event = eventId,
+                club = clubId,
+                createdAt = CHAIN_SEED_TIME,
+                createdBy = createdBy,
+                updatedAt = CHAIN_SEED_TIME,
+            )
+        )
+        return id
+    }
+
+    /**
+     * Zwei Regatten, drei meldende Vereine. Rostock hat gemeldet, sein Nutzer ist aber gelöscht -
+     * das ist der Fall, den die Liste zeigen und der Versand ablehnen muss.
+     */
+    private fun TestComprehensionScope<JEnv>.seedMailEvent(): SeededMailEvent {
+        val eventId = UUID.randomUUID()
+        val otherEventId = UUID.randomUUID()
+        !EVENT.insert(
+            EventRecord(id = eventId, name = "Testregatta", createdAt = CHAIN_SEED_TIME, updatedAt = CHAIN_SEED_TIME)
+        )
+        !EVENT.insert(
+            EventRecord(
+                id = otherEventId,
+                name = "Nachbarregatta",
+                createdAt = CHAIN_SEED_TIME,
+                updatedAt = CHAIN_SEED_TIME,
+            )
+        )
+
+        val kielId = seedClub("Kieler Ruder-Club")
+        val flensburgId = seedClub("Ruderklub Flensburg")
+        val rostockId = seedClub("Rostocker Ruder-Club")
+
+        val kielUser = seedUser(kielEmail, "Kai", "Kieler")
+        val flensburgUser = seedUser(flensburgEmail, "Frauke", "Flensburger")
+
+        // Dieselben Vereine und derselbe Nutzer melden auch nebenan - diese Meldungen dürfen in
+        // der Liste der Testregatta nicht auftauchen.
+        seedRegistration(otherEventId, kielId, kielUser)
+        seedRegistration(otherEventId, flensburgId, flensburgUser)
+
+        return SeededMailEvent(
+            eventId = eventId,
+            otherEventId = otherEventId,
+            kielRegistrationId = seedRegistration(eventId, kielId, kielUser),
+            flensburgRegistrationId = seedRegistration(eventId, flensburgId, flensburgUser),
+            rostockRegistrationId = seedRegistration(eventId, rostockId, null),
+        )
+    }
+
+    private fun request(
+        registrationIds: List<UUID>,
+        additionalAddresses: List<String> = emptyList(),
+        subject: String = "Hinweise zum Regattatag",
+        body: String = "Moin,\nbitte denkt an die Waage.",
+    ) = RegistrationMailRequest(
+        subject = subject,
+        body = body,
+        registrationIds = registrationIds,
+        additionalAddresses = additionalAddresses,
+    )
+
+    @Test
+    fun theRecipientListNamesEveryRegistrantOfTheEventAndNobodyElse() = testComprehension {
+        val seeded = seedMailEvent()
+
+        val recipients = (!RegistrationMailService.getRecipients(seeded.eventId)).data
+
+        assertContentEquals(
+            listOf("Kieler Ruder-Club", "Rostocker Ruder-Club", "Ruderklub Flensburg"),
+            recipients.map { it.clubName },
+            "alle Melder der Testregatta, nach Verein sortiert - und nur die",
+        )
+
+        val kiel = recipients.single { it.clubName == "Kieler Ruder-Club" }
+        assertEquals(seeded.kielRegistrationId, kiel.registrationId)
+        assertEquals(kielEmail, kiel.email)
+        assertEquals("Kai Kieler", kiel.name)
+
+        // Gelöschter Melder: die Meldung bleibt sichtbar, die Adresse fehlt. Ohne diese Zeile
+        // wüsste die Regattaleitung nicht, dass dieser Verein die Rundmail nicht bekommt.
+        val rostock = recipients.single { it.clubName == "Rostocker Ruder-Club" }
+        assertNull(rostock.email)
+        assertNull(rostock.name)
+    }
+
+    @Test
+    fun everySelectedRecipientGetsAnOwnMailIncludingTheAttachments() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        val result = !RegistrationMailService.send(
+            eventId = seeded.eventId,
+            request = request(
+                registrationIds = listOf(seeded.kielRegistrationId, seeded.flensburgRegistrationId),
+                additionalAddresses = listOf("presse@example.org"),
+            ),
+            attachments = listOf(
+                EmailAttachment(name = "zeitplan.pdf", data = byteArrayOf(1, 2, 3)),
+                EmailAttachment(name = "anfahrt.pdf", data = byteArrayOf(4, 5)),
+            ),
+            userId = sender,
+        )
+
+        assertEquals(3, result.dto.enqueued)
+
+        val mails = !Jooq.query { selectFrom(EMAIL).orderBy(EMAIL.RECIPIENT).fetch() }
+        assertContentEquals(
+            listOf("flensburg@example.org", "kiel@example.org", "presse@example.org"),
+            mails.map { it.recipient },
+        )
+        assertTrue(mails.all { it.subject == "Hinweise zum Regattatag" })
+        assertTrue(mails.none { it.bodyIsHtml }, "der frei getippte Text geht als Klartext raus")
+
+        // Ein Fehlversand muss am Tag danach noch nachweisbar sein - deshalb überlebt die Zeile
+        // das Senden, statt wie sonst sofort von deleteSent() geholt zu werden.
+        assertTrue(mails.all { it.keepAfterSending == RegistrationMailService.KEEP_AFTER_SENDING_SECONDS })
+
+        mails.forEach { mail ->
+            val attachments = !Jooq.query {
+                selectFrom(EMAIL_ATTACHMENT)
+                    .where(EMAIL_ATTACHMENT.EMAIL.eq(mail.id))
+                    .orderBy(EMAIL_ATTACHMENT.NAME)
+                    .fetch()
+            }
+            assertContentEquals(
+                listOf("anfahrt.pdf", "zeitplan.pdf"),
+                attachments.map { it.name },
+                "auch die letzte Mail trägt noch beide Anhänge (${mail.recipient})",
+            )
+            assertContentEquals(byteArrayOf(4, 5), attachments.first().data)
+        }
+    }
+
+    @Test
+    fun placeholdersAreFilledPerRecipientAndStayEmptyForFreeAddresses() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        !RegistrationMailService.send(
+            eventId = seeded.eventId,
+            request = request(
+                registrationIds = listOf(seeded.kielRegistrationId),
+                additionalAddresses = listOf("presse@example.org"),
+                subject = "##event##: Hinweise",
+                body = "Hallo ##recipient##, für ##club## zur ##event##.",
+            ),
+            attachments = emptyList(),
+            userId = sender,
+        )
+
+        val byRecipient = (!Jooq.query { selectFrom(EMAIL).fetch() }).associateBy { it.recipient }
+
+        assertEquals("Testregatta: Hinweise", byRecipient[kielEmail]?.subject)
+        assertEquals("Hallo Kai Kieler, für Kieler Ruder-Club zur Testregatta.", byRecipient[kielEmail]?.body)
+
+        // Freie Adressen kennen weder Person noch Verein. Die Platzhalter müssen trotzdem
+        // verschwinden - sonst steht "##club##" wörtlich in der Mail an die Presse.
+        assertEquals("Hallo , für  zur Testregatta.", byRecipient["presse@example.org"]?.body)
+    }
+
+    @Test
+    fun aRegistrationWithoutAUserIsRefusedInsteadOfSilentlySkipped() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        assertKIOFails(EventRegistrationError.MailRecipientWithoutUser(seeded.rostockRegistrationId)) {
+            RegistrationMailService.send(
+                eventId = seeded.eventId,
+                request = request(listOf(seeded.kielRegistrationId, seeded.rostockRegistrationId)),
+                attachments = emptyList(),
+                userId = sender,
+            )
+        }
+
+        assertEquals(0, !Jooq.query { fetchCount(EMAIL) }, "entweder alle oder keine")
+    }
+
+    @Test
+    fun aRegistrationOfAnotherEventIsRefused() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        val foreign = !Jooq.query {
+            selectFrom(EVENT_REGISTRATION)
+                .where(EVENT_REGISTRATION.EVENT.eq(seeded.otherEventId))
+                .fetch()
+                .first()
+                .id
+        }
+
+        assertKIOFails(EventRegistrationError.MailRecipientNotFound(foreign)) {
+            RegistrationMailService.send(
+                eventId = seeded.eventId,
+                request = request(listOf(seeded.kielRegistrationId, foreign)),
+                attachments = emptyList(),
+                userId = sender,
+            )
+        }
+    }
+
+    @Test
+    fun sendingWithoutAnyRecipientFails() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        assertKIOFails(EventRegistrationError.MailWithoutRecipients) {
+            RegistrationMailService.send(
+                eventId = seeded.eventId,
+                request = request(emptyList()),
+                attachments = emptyList(),
+                userId = sender,
+            )
+        }
+    }
+
+    @Test
+    fun anUnusableFreeAddressFails() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        assertKIOFails(EventRegistrationError.MailAddressInvalid("presse(at)example.org")) {
+            RegistrationMailService.send(
+                eventId = seeded.eventId,
+                request = request(
+                    registrationIds = listOf(seeded.kielRegistrationId),
+                    additionalAddresses = listOf("presse(at)example.org"),
+                ),
+                attachments = emptyList(),
+                userId = sender,
+            )
+        }
+    }
+
+    @Test
+    fun anAddressIsWrittenOnlyOnce() = testComprehension {
+        val seeded = seedMailEvent()
+        val sender = seedUser("leitung@example.org", "Ilka", "Regattaleitung")
+
+        // Die Regattaleitung tippt eine Adresse dazu, die schon als Melder in der Liste steht -
+        // und schreibt sie versehentlich groß.
+        val result = !RegistrationMailService.send(
+            eventId = seeded.eventId,
+            request = request(
+                registrationIds = listOf(seeded.kielRegistrationId),
+                additionalAddresses = listOf("KIEL@example.org"),
+            ),
+            attachments = emptyList(),
+            userId = sender,
+        )
+
+        assertEquals(1, result.dto.enqueued)
+        assertEquals(1, !Jooq.query { fetchCount(EMAIL) })
+        // Der Melder gewinnt: seine Mail ist die mit Namen und Verein in den Platzhaltern.
+        assertEquals(kielEmail, !Jooq.query { selectFrom(EMAIL).fetchSingle().recipient })
+    }
+}

--- a/frontend/src/api/sdk.gen.ts
+++ b/frontend/src/api/sdk.gen.ts
@@ -449,6 +449,12 @@ import type {
     AcceptEventRegistrationDocumentsData,
     AcceptEventRegistrationDocumentsError,
     AcceptEventRegistrationDocumentsResponse,
+    GetRegistrationMailRecipientsData,
+    GetRegistrationMailRecipientsError,
+    GetRegistrationMailRecipientsResponse,
+    SendRegistrationMailData,
+    SendRegistrationMailError,
+    SendRegistrationMailResponse,
     GetEventRegistrationTemplateData,
     GetEventRegistrationTemplateError,
     GetEventRegistrationTemplateResponse,
@@ -2915,6 +2921,37 @@ export const acceptEventRegistrationDocuments = <ThrowOnError extends boolean = 
     >({
         ...options,
         url: '/event/{eventId}/eventRegistration/acceptDocuments',
+    })
+}
+
+export const getRegistrationMailRecipients = <ThrowOnError extends boolean = false>(
+    options: OptionsLegacyParser<GetRegistrationMailRecipientsData, ThrowOnError>,
+) => {
+    return (options?.client ?? client).get<
+        GetRegistrationMailRecipientsResponse,
+        GetRegistrationMailRecipientsError,
+        ThrowOnError
+    >({
+        ...options,
+        url: '/event/{eventId}/eventRegistration/mailRecipients',
+    })
+}
+
+export const sendRegistrationMail = <ThrowOnError extends boolean = false>(
+    options: OptionsLegacyParser<SendRegistrationMailData, ThrowOnError>,
+) => {
+    return (options?.client ?? client).post<
+        SendRegistrationMailResponse,
+        SendRegistrationMailError,
+        ThrowOnError
+    >({
+        ...options,
+        ...formDataBodySerializer,
+        headers: {
+            'Content-Type': null,
+            ...options?.headers,
+        },
+        url: '/event/{eventId}/eventRegistration/mail',
     })
 }
 

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3346,6 +3346,25 @@ export type RatingCategoryToEventRequest = {
 
 export type RegistrationInvoiceType = 'REGULAR' | 'LATE'
 
+export type RegistrationMailRecipientDto = {
+    registrationId: string
+    clubId: string
+    clubName: string
+    name?: string
+    email?: string
+}
+
+export type RegistrationMailRequest = {
+    subject: string
+    body: string
+    registrationIds: Array<string>
+    additionalAddresses: Array<string>
+}
+
+export type RegistrationMailResultDto = {
+    enqueued: number
+}
+
 export type ResendAccessTokenRequest = {
     callbackUrl: string
 }
@@ -6251,6 +6270,30 @@ export type AcceptEventRegistrationDocumentsError =
     | BadRequestError
     | ApiError
     | UnprocessableEntityError
+
+export type GetRegistrationMailRecipientsData = {
+    path: {
+        eventId: string
+    }
+}
+
+export type GetRegistrationMailRecipientsResponse = Array<RegistrationMailRecipientDto>
+
+export type GetRegistrationMailRecipientsError = ApiError
+
+export type SendRegistrationMailData = {
+    body: {
+        request: RegistrationMailRequest
+        files?: Array<Blob | File>
+    }
+    path: {
+        eventId: string
+    }
+}
+
+export type SendRegistrationMailResponse = RegistrationMailResultDto
+
+export type SendRegistrationMailError = BadRequestError | ApiError | UnprocessableEntityError
 
 export type GetEventRegistrationTemplateData = {
     path: {

--- a/frontend/src/components/event/competition/registration/EventRegistrations.tsx
+++ b/frontend/src/components/event/competition/registration/EventRegistrations.tsx
@@ -1,6 +1,9 @@
 import FinalizeRegistrations from '@components/event/competition/excecution/FinalizeRegistrations.tsx'
 import EventRegistrationTable from '@components/eventRegistration/EventRegistrationTable.tsx'
-import {Stack} from '@mui/material'
+import RegistrationMailDialog from '@components/eventRegistration/RegistrationMailDialog.tsx'
+import {Box, Button, Stack} from '@mui/material'
+import {Email} from '@mui/icons-material'
+import {useState} from 'react'
 import {useEntityAdministration} from '@utils/hooks.ts'
 import {EventDto, EventRegistrationViewDto} from '@api/types.gen.ts'
 import {eventRoute} from '@routes'
@@ -15,6 +18,8 @@ const EventRegistrations = (props: Props) => {
 
     const {eventId} = eventRoute.useParams()
 
+    const [mailDialogOpen, setMailDialogOpen] = useState(false)
+
     const eventRegistrationProps = useEntityAdministration<EventRegistrationViewDto>(
         t('event.registration.registration'),
         {entityCreate: false, entityUpdate: false},
@@ -25,9 +30,19 @@ const EventRegistrations = (props: Props) => {
             {!props.eventDto.challengeEvent && (
                 <FinalizeRegistrations registrationsFinalized={props.registrationsFinalized} />
             )}
+            <Box>
+                <Button startIcon={<Email />} onClick={() => setMailDialogOpen(true)}>
+                    {t('event.registration.mail.open')}
+                </Button>
+            </Box>
             <EventRegistrationTable
                 {...eventRegistrationProps.table}
                 title={t('event.registration.registrations')}
+                eventId={eventId}
+            />
+            <RegistrationMailDialog
+                open={mailDialogOpen}
+                onClose={() => setMailDialogOpen(false)}
                 eventId={eventId}
             />
         </Stack>

--- a/frontend/src/components/eventRegistration/RegistrationMailDialog.tsx
+++ b/frontend/src/components/eventRegistration/RegistrationMailDialog.tsx
@@ -1,0 +1,351 @@
+import {
+    Alert,
+    Box,
+    Button,
+    Checkbox,
+    Chip,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    IconButton,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material'
+import {Delete} from '@mui/icons-material'
+import {KeyboardEvent, useCallback, useState} from 'react'
+import {useTranslation} from 'react-i18next'
+import BaseDialog from '@components/BaseDialog.tsx'
+import SelectFileButton from '@components/SelectFileButton.tsx'
+import Throbber from '@components/Throbber.tsx'
+import {useFeedback, useFetch} from '@utils/hooks.ts'
+import {getRegistrationMailRecipients, sendRegistrationMail} from '@api/sdk.gen.ts'
+import {RegistrationMailRecipientDto} from '@api/types.gen.ts'
+
+type Props = {
+    open: boolean
+    onClose: () => void
+    eventId: string
+}
+
+/** Ab hier warnt der Dialog: Anhänge werden je Empfänger kopiert. */
+const ATTACHMENT_WARNING_BYTES = 5 * 1024 * 1024
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
+
+const formatSize = (bytes: number) =>
+    bytes < 1024 * 1024 ? `${Math.round(bytes / 1024)} KB` : `${(bytes / 1024 / 1024).toFixed(1)} MB`
+
+const RegistrationMailDialog = ({open, onClose, eventId}: Props) => {
+    const {t} = useTranslation()
+    const feedback = useFeedback()
+
+    const [selected, setSelected] = useState<string[]>([])
+    const [addresses, setAddresses] = useState<string[]>([])
+    const [addressInput, setAddressInput] = useState('')
+    const [addressError, setAddressError] = useState<string | null>(null)
+    const [subject, setSubject] = useState('')
+    const [body, setBody] = useState('')
+    const [files, setFiles] = useState<File[]>([])
+    const [confirming, setConfirming] = useState(false)
+    const [submitting, setSubmitting] = useState(false)
+
+    const {data, pending} = useFetch(
+        signal => getRegistrationMailRecipients({signal, path: {eventId}}),
+        {
+            // Beim Öffnen sind alle erreichbaren Melder angehakt - der Regelfall ist "an alle".
+            onResponse: ({data}) => {
+                if (data) {
+                    setSelected(
+                        data
+                            .filter((r: RegistrationMailRecipientDto) => r.email)
+                            .map((r: RegistrationMailRecipientDto) => r.registrationId),
+                    )
+                }
+            },
+            preCondition: () => open,
+            deps: [open, eventId],
+        },
+    )
+
+    const recipients = data ?? []
+    const reachable = recipients.filter(r => r.email)
+    const attachmentBytes = files.reduce((sum, file) => sum + file.size, 0)
+    const totalRecipients = selected.length + addresses.length
+
+    const toggle = (registrationId: string) =>
+        setSelected(prev =>
+            prev.includes(registrationId)
+                ? prev.filter(id => id !== registrationId)
+                : [...prev, registrationId],
+        )
+
+    const commitAddress = useCallback(() => {
+        const address = addressInput.trim()
+        if (address === '') {
+            return
+        }
+        if (!emailPattern.test(address)) {
+            setAddressError(t('event.registration.mail.error.invalidAddress', {address}))
+            return
+        }
+        setAddressError(null)
+        setAddresses(prev =>
+            prev.some(a => a.toLowerCase() === address.toLowerCase()) ? prev : [...prev, address],
+        )
+        setAddressInput('')
+    }, [addressInput, t])
+
+    const onAddressKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ',') {
+            event.preventDefault()
+            commitAddress()
+        }
+    }
+
+    const reset = () => {
+        setAddresses([])
+        setAddressInput('')
+        setAddressError(null)
+        setSubject('')
+        setBody('')
+        setFiles([])
+        setConfirming(false)
+    }
+
+    const close = () => {
+        reset()
+        onClose()
+    }
+
+    const send = async () => {
+        setSubmitting(true)
+        // Ohne das try bleibt der Dialog nach einem Netzfehler mit gesperrtem Knopf stehen -
+        // der abgewiesene Aufruf käme nie bis zum setSubmitting(false) unten.
+        let result
+        try {
+            result = await sendRegistrationMail({
+                path: {eventId},
+                body: {
+                    request: {
+                        subject,
+                        body,
+                        registrationIds: selected,
+                        additionalAddresses: addresses,
+                    },
+                    files,
+                },
+            })
+        } catch {
+            setSubmitting(false)
+            setConfirming(false)
+            feedback.error(t('common.error.unexpected'))
+            return
+        }
+        const {data, error} = result
+        setSubmitting(false)
+        setConfirming(false)
+
+        if (error) {
+            if (error.status.value === 409) {
+                feedback.error(t('event.registration.mail.error.recipientGone'))
+            } else {
+                feedback.error(t('common.error.unexpected'))
+            }
+        } else {
+            feedback.success(
+                t('event.registration.mail.success', {count: data?.enqueued ?? totalRecipients}),
+            )
+            close()
+        }
+    }
+
+    const canSend = totalRecipients > 0 && subject.trim() !== '' && body.trim() !== ''
+
+    return (
+        <>
+            <BaseDialog open={open} onClose={close} maxWidth={'md'}>
+                <DialogTitle>{t('event.registration.mail.title')}</DialogTitle>
+                <DialogContent dividers>
+                    {pending ? (
+                        <Throbber />
+                    ) : (
+                        <Stack spacing={3}>
+                            <Box>
+                                <Stack
+                                    direction={'row'}
+                                    justifyContent={'space-between'}
+                                    alignItems={'center'}>
+                                    <Typography variant={'subtitle1'}>
+                                        {t('event.registration.mail.recipients')}
+                                    </Typography>
+                                    <Button
+                                        size={'small'}
+                                        onClick={() =>
+                                            setSelected(
+                                                selected.length === reachable.length
+                                                    ? []
+                                                    : reachable.map(r => r.registrationId),
+                                            )
+                                        }>
+                                        {selected.length === reachable.length
+                                            ? t('common.deselectAll')
+                                            : t('common.selectAll')}
+                                    </Button>
+                                </Stack>
+                                <Box sx={{maxHeight: 260, overflowY: 'auto'}}>
+                                    {recipients.map(recipient => (
+                                        <Stack
+                                            key={recipient.registrationId}
+                                            direction={'row'}
+                                            alignItems={'center'}
+                                            spacing={1}>
+                                            <Checkbox
+                                                size={'small'}
+                                                disabled={!recipient.email}
+                                                checked={selected.includes(recipient.registrationId)}
+                                                onChange={() => toggle(recipient.registrationId)}
+                                            />
+                                            <Box>
+                                                <Typography variant={'body2'}>
+                                                    {recipient.clubName}
+                                                </Typography>
+                                                <Typography
+                                                    variant={'caption'}
+                                                    color={
+                                                        recipient.email
+                                                            ? 'text.secondary'
+                                                            : 'error'
+                                                    }>
+                                                    {recipient.email
+                                                        ? `${recipient.name} · ${recipient.email}`
+                                                        : t('event.registration.mail.noUser')}
+                                                </Typography>
+                                            </Box>
+                                        </Stack>
+                                    ))}
+                                </Box>
+                            </Box>
+
+                            <Divider />
+
+                            <Box>
+                                <TextField
+                                    fullWidth
+                                    size={'small'}
+                                    label={t('event.registration.mail.additionalAddresses')}
+                                    placeholder={t('event.registration.mail.addressHint')}
+                                    value={addressInput}
+                                    error={addressError !== null}
+                                    helperText={addressError}
+                                    onChange={e => setAddressInput(e.target.value)}
+                                    onKeyDown={onAddressKeyDown}
+                                    onBlur={commitAddress}
+                                />
+                                {addresses.length > 0 && (
+                                    <Stack direction={'row'} flexWrap={'wrap'} gap={1} mt={1}>
+                                        {addresses.map(address => (
+                                            <Chip
+                                                key={address}
+                                                label={address}
+                                                size={'small'}
+                                                onDelete={() =>
+                                                    setAddresses(prev =>
+                                                        prev.filter(a => a !== address),
+                                                    )
+                                                }
+                                            />
+                                        ))}
+                                    </Stack>
+                                )}
+                            </Box>
+
+                            <TextField
+                                fullWidth
+                                size={'small'}
+                                label={t('event.registration.mail.subject')}
+                                value={subject}
+                                onChange={e => setSubject(e.target.value)}
+                            />
+                            <TextField
+                                fullWidth
+                                multiline
+                                minRows={8}
+                                label={t('event.registration.mail.body')}
+                                helperText={t('event.registration.mail.placeholders')}
+                                value={body}
+                                onChange={e => setBody(e.target.value)}
+                            />
+
+                            <Box>
+                                <Typography variant={'subtitle1'}>
+                                    {t('event.registration.mail.attachments')}
+                                </Typography>
+                                {files.map((file, index) => (
+                                    <Stack
+                                        key={`${file.name}-${index}`}
+                                        direction={'row'}
+                                        alignItems={'center'}
+                                        justifyContent={'space-between'}>
+                                        <Typography variant={'body2'}>
+                                            {file.name} ({formatSize(file.size)})
+                                        </Typography>
+                                        <IconButton
+                                            size={'small'}
+                                            onClick={() =>
+                                                setFiles(prev => prev.filter((_, i) => i !== index))
+                                            }>
+                                            <Delete fontSize={'small'} />
+                                        </IconButton>
+                                    </Stack>
+                                ))}
+                                <SelectFileButton
+                                    variant={'text'}
+                                    multiple
+                                    onSelected={selectedFiles =>
+                                        setFiles(prev => [...prev, ...Array.from(selectedFiles)])
+                                    }>
+                                    {t('event.registration.mail.addAttachment')}
+                                </SelectFileButton>
+                                {attachmentBytes > ATTACHMENT_WARNING_BYTES && (
+                                    <Alert severity={'warning'}>
+                                        {t('event.registration.mail.attachmentWarning', {
+                                            size: formatSize(attachmentBytes),
+                                        })}
+                                    </Alert>
+                                )}
+                            </Box>
+                        </Stack>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={close}>{t('common.cancel')}</Button>
+                    <Button
+                        variant={'contained'}
+                        disabled={!canSend}
+                        onClick={() => setConfirming(true)}>
+                        {t('event.registration.mail.send')}
+                    </Button>
+                </DialogActions>
+            </BaseDialog>
+
+            <BaseDialog open={confirming} onClose={() => setConfirming(false)} maxWidth={'xs'}>
+                <DialogTitle>{t('event.registration.mail.confirm.title')}</DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        {t('event.registration.mail.confirm.text', {count: totalRecipients})}
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirming(false)}>{t('common.cancel')}</Button>
+                    <Button variant={'contained'} disabled={submitting} onClick={send}>
+                        {t('event.registration.mail.send')}
+                    </Button>
+                </DialogActions>
+            </BaseDialog>
+        </>
+    )
+}
+
+export default RegistrationMailDialog

--- a/frontend/src/i18n/da/translations.json
+++ b/frontend/src/i18n/da/translations.json
@@ -1554,7 +1554,31 @@
       },
       "mostRecent": "Nyeste tilmeldinger",
       "teams": "Hold",
-      "teamMembers": "Holdmedlemmer"
+      "teamMembers": "Holdmedlemmer",
+      "mail": {
+        "open": "Skriv rundmail",
+        "title": "Rundmail til tilmelderne",
+        "recipients": "Modtagere",
+        "noUser": "ingen bruger længere – får ingen mail",
+        "additionalAddresses": "Yderligere adresser",
+        "addressHint": "Indtast en adresse og tryk Enter",
+        "subject": "Emne",
+        "body": "Tekst",
+        "placeholders": "Pladsholdere: ##recipient##, ##club##, ##event## – erstattes pr. modtager",
+        "attachments": "Vedhæftede filer",
+        "addAttachment": "Vedhæft fil",
+        "attachmentWarning": "De vedhæftede filer fylder tilsammen {{size}} og sendes til hver modtager for sig.",
+        "send": "Send",
+        "success": "{{count}} e-mails sat i kø",
+        "confirm": {
+          "title": "Send rundmail?",
+          "text": "Mailen går til {{count}} modtagere. Når den er sendt, kan den ikke kaldes tilbage."
+        },
+        "error": {
+          "invalidAddress": "Ikke en gyldig adresse: {{address}}",
+          "recipientGone": "En tilmelder har ikke længere en bruger. Åbn dialogen igen."
+        }
+      }
     },
     "participants": "Deltagere",
     "tabs": {

--- a/frontend/src/i18n/de/translations.json
+++ b/frontend/src/i18n/de/translations.json
@@ -1554,7 +1554,31 @@
       },
       "mostRecent": "Neuste Anmeldungen",
       "teams": "Teams",
-      "teamMembers": "Teammitglieder"
+      "teamMembers": "Teammitglieder",
+      "mail": {
+        "open": "Rundmail schreiben",
+        "title": "Rundmail an die Melder",
+        "recipients": "Empfänger",
+        "noUser": "kein Benutzer mehr – bekommt keine Mail",
+        "additionalAddresses": "Weitere Adressen",
+        "addressHint": "Adresse eingeben und Enter drücken",
+        "subject": "Betreff",
+        "body": "Text",
+        "placeholders": "Platzhalter: ##recipient##, ##club##, ##event## – werden je Empfänger ersetzt",
+        "attachments": "Anhänge",
+        "addAttachment": "Datei anhängen",
+        "attachmentWarning": "Die Anhänge sind zusammen {{size}} groß und werden für jeden Empfänger einzeln verschickt.",
+        "send": "Senden",
+        "success": "{{count}} E-Mails eingereiht",
+        "confirm": {
+          "title": "Rundmail senden?",
+          "text": "Die Mail geht an {{count}} Empfänger. Einmal abgeschickt lässt sie sich nicht mehr zurückholen."
+        },
+        "error": {
+          "invalidAddress": "Keine gültige Adresse: {{address}}",
+          "recipientGone": "Ein Melder hat inzwischen keinen Benutzer mehr. Bitte den Dialog neu öffnen."
+        }
+      }
     },
     "participants": "Teilnehmende",
     "tabs": {

--- a/frontend/src/i18n/en/translations.json
+++ b/frontend/src/i18n/en/translations.json
@@ -1554,7 +1554,31 @@
       },
       "mostRecent": "Latest registrations",
       "teams": "Teams",
-      "teamMembers": "Team members"
+      "teamMembers": "Team members",
+      "mail": {
+        "open": "Write bulk mail",
+        "title": "Bulk mail to registrants",
+        "recipients": "Recipients",
+        "noUser": "no user left – will not receive a mail",
+        "additionalAddresses": "Additional addresses",
+        "addressHint": "Type an address and press Enter",
+        "subject": "Subject",
+        "body": "Text",
+        "placeholders": "Placeholders: ##recipient##, ##club##, ##event## – replaced per recipient",
+        "attachments": "Attachments",
+        "addAttachment": "Attach file",
+        "attachmentWarning": "The attachments add up to {{size}} and are sent to every recipient separately.",
+        "send": "Send",
+        "success": "{{count}} emails enqueued",
+        "confirm": {
+          "title": "Send bulk mail?",
+          "text": "The mail goes out to {{count}} recipients. Once sent it cannot be recalled."
+        },
+        "error": {
+          "invalidAddress": "Not a valid address: {{address}}",
+          "recipientGone": "One registrant no longer has a user. Please reopen the dialog."
+        }
+      }
     },
     "participants": "Participants",
     "tabs": {


### PR DESCRIPTION
## Worum es geht

Wer allen Vereinen, die zu einer Veranstaltung gemeldet haben, etwas mitteilen will — geänderter Zeitplan, Hinweise zur Anfahrt, Nachforderung von Unterlagen — musste die Adressen bisher aus der Meldeliste zusammensuchen und im eigenen Mailprogramm zusammenstellen. Dieser PR bringt das in die Anwendung.

Der PR ist bewusst klein und eigenständig gehalten, weil das Feature für eine anstehende Regatta gebraucht wird.

## Was der Nutzer sieht

Auf dem Meldungen-Reiter einer Veranstaltung gibt es den Knopf **„Rundmail schreiben"**. Der Dialog enthält:

- **Empfängerliste** — alle Melder der Veranstaltung mit Verein, Name und Adresse, vorausgewählt, einzeln abwählbar
- **Weitere Adressen** — von Hand ergänzte Adressen als Chips, Format wird beim Eintippen geprüft
- **Betreff und Text** — frei getippt, mit den Platzhaltern `##recipient##`, `##club##` und `##event##`
- **Anhänge** — beliebig viele Dateien, mit Größenangabe und Warnung ab 5 MB Gesamtgröße

Vor dem Absenden fragt ein Dialog mit der Empfängerzahl nach, weil sich eine eingereihte Mail nicht mehr zurückholen lässt.

## Entwurfsentscheidungen

**Der Empfängerkreis hängt an `event_registration.created_by`, nicht am Verein.** Ein Verein kann Nutzer haben, die zu dieser Veranstaltung nichts gemeldet haben, und meldet zu mehreren Veranstaltungen — ein Join über den Verein besteht jede Einzelprüfung und schreibt am Regattatag trotzdem die halbe Nachbarveranstaltung an. Der Test hält diesen Fall mit einer zweiten Veranstaltung fest.

**Gelöschte Ersteller bleiben sichtbar.** Steht `created_by` per `on delete set null` auf NULL, erscheint die Meldung weiter in der Liste, mit rotem Hinweis und nicht anwählbar. Blendete man sie aus, fiele niemandem auf, dass dieser Verein nichts bekommt. Kommt eine solche Meldung trotzdem beim Server an — veralteter Dialog —, wird der ganze Versand abgelehnt, statt still jemanden auszulassen.

**Eine eigene Mail je Empfänger** statt einer Sammelmail mit BCC: die Adressen sehen sich nicht, und die Platzhalter lassen sich je Empfänger füllen. Bei frei ergänzten Adressen bleiben Person und Verein leer. Fällt eine ergänzte Adresse mit der eines Melders zusammen, gewinnt der Melder — nur seine Mail kennt die Platzhalterwerte.

**Die Mailzeilen überleben das Senden um sieben Tage,** statt wie sonst sofort von `deleteSent()` geholt zu werden. Geht am Regattatag etwas an den falschen Kreis raus, muss am Tag danach noch nachweisbar sein, was an wen ging.

**Der Dienst liegt neben `EventRegistrationService`, nicht darin.** Die Meldelogik dort ist mit über 1200 Zeilen reichlich, und mit dem Meldevorgang selbst hat das Anschreiben nichts zu tun.

## Umfang

- **Keine Migration** — `email` und `email_attachment` tragen Empfänger und Anhänge schon; der Versand nutzt `EmailService.enqueue` unverändert.
- **Zwei Endpunkte** unter der bestehenden Meldungs-Route: `GET …/eventRegistration/mailRecipients` und `POST …/eventRegistration/mail` (multipart, nach dem Muster des Vereins-CSV-Imports).
- **Recht:** `UpdateEventGlobal` — wer die Veranstaltung verwaltet, darf ihre Melder anschreiben. Kein neues Privileg. Sagt uns Bescheid, wenn ihr das lieber getrennt hättet.

## Bekannte Abwägung

Anhänge werden je Empfänger kopiert, solange die Mail in der Warteschlange steht — bei 40 Meldern und 3 MB PDF also rund 120 MB in `email_attachment`, bis die Queue durch ist. Für die Größenordnungen einer Regatta unkritisch; der Dialog warnt ab 5 MB Gesamtgröße.

## Geprüft

- Neuer Test `RegistrationMailTest` gegen ein echtes Postgres (Testcontainers), acht Fälle: Empfängerliste je Veranstaltung, gelöschter Ersteller, eine Mail je Empfänger samt Anhängen, Platzhalter je Empfänger, fremde Meldung, leerer Empfängerkreis, unbrauchbare Adresse, doppelte Adresse.
- Volle Backend-Suite (1077 Tests) und Frontend-Suite (1165 Tests) grün, `npm run build` und Lint der neuen Dateien sauber.
- Von Hand im Browser durchgespielt: Auswahl, ergänzte Adresse, Anhang, Bestätigung — vier Mails mit je eigenem Text und Anhang in der Warteschlange.