### PR TITLE
Rundenband im Livestream: die zuletzt eingetroffene Zeit steht wieder vorn

### DIFF
--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
@@ -1552,8 +1552,10 @@ object CompetitionExecutionService {
                     }.orDie()
                 }
 
-                !CompetitionMatchTeamLapRepo.deleteByTeam(team.id!!).orDie()
-
+                // Upsert statt Löschen + Einfügen: `created_at` ist der Zeitpunkt, zu dem eine
+                // Marke ZUERST da war, und genau daran hängt die Reihenfolge des Rundenbands im
+                // Livestream. Beim vollständigen Ersetzen trug jede Runde den Zeitstempel des
+                // letzten Takts - alle gleich, bei jedem Takt neu.
                 if (start != null) {
                     val records = row.laps.mapIndexed { index, lap ->
                         var millis = java.time.Duration.between(start, lap.time).toMillis()
@@ -1568,9 +1570,12 @@ object CompetitionExecutionService {
                             createdBy = userId,
                         )
                     }
-                    if (records.isNotEmpty()) {
-                        !CompetitionMatchTeamLapRepo.create(records).orDie()
-                    }
+                    !CompetitionMatchTeamLapRepo.upsert(records).orDie()
+                    // Was der Feed nicht mehr führt, verschwindet - eine zurückgenommene Marke
+                    // bliebe sonst stehen.
+                    !CompetitionMatchTeamLapRepo.deleteBeyond(team.id!!, records.map { it.position!! }).orDie()
+                } else {
+                    !CompetitionMatchTeamLapRepo.deleteByTeam(team.id!!).orDie()
                 }
 
                 KIO.unit

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/CompetitionMatchTeamLapRepo.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/CompetitionMatchTeamLapRepo.kt
@@ -14,7 +14,47 @@ object CompetitionMatchTeamLapRepo {
 
     fun create(records: List<CompetitionMatchTeamLapRecord>) = COMPETITION_MATCH_TEAM_LAP.insert(records)
 
-    /** Alle Runden eines Boots - der Abruf ersetzt sie je Takt vollständig (Löschen + Einfügen). */
+    /**
+     * Schreibt die Runden eines Boots, ohne ihren Erfassungszeitpunkt zu verlieren.
+     *
+     * Der Abruf ersetzte sie bis zum 15.08.2026 je Takt vollständig (Löschen + Einfügen mit
+     * `created_at = now`). Damit trug jede Runde denselben, bei jedem Takt neuen Zeitstempel -
+     * und das Rundenband des Livestreams, das "zuletzt eingetroffen" danach sortiert, hatte
+     * nichts zu sortieren: Es fiel auf den Rundennamen zurück und zeigte ewig 1, 2, 3.
+     *
+     * Der Upsert trifft die Zeile über den eindeutigen Index (Boot, Position) und lässt
+     * `created_at` stehen. Der Zeitstempel bedeutet damit, was sein Name sagt: wann diese Marke
+     * zum ersten Mal da war. Name und Zeit werden nachgezogen - der Zeitnehmer darf eine Marke
+     * umbenennen oder korrigieren.
+     */
+    fun upsert(records: List<CompetitionMatchTeamLapRecord>) = Jooq.query {
+        with(COMPETITION_MATCH_TEAM_LAP) {
+            records.forEach { record ->
+                insertInto(this)
+                    .set(record)
+                    .onConflict(COMPETITION_MATCH_TEAM, POSITION)
+                    .doUpdate()
+                    .set(NAME, record.name)
+                    .set(LAP_MILLIS, record.lapMillis)
+                    .execute()
+            }
+        }
+    }
+
+    /**
+     * Löscht die Marken jenseits von [keepPositions] - das Gegenstück zum Upsert, für den Fall,
+     * dass der Zeitnehmer eine Marke wieder entfernt. Ohne das bliebe sie stehen, weil der Upsert
+     * nur schreibt, was der Feed liefert.
+     */
+    fun deleteBeyond(teamId: UUID, keepPositions: Collection<Int>) =
+        COMPETITION_MATCH_TEAM_LAP.delete {
+            COMPETITION_MATCH_TEAM.eq(teamId).and(
+                if (keepPositions.isEmpty()) org.jooq.impl.DSL.trueCondition()
+                else POSITION.notIn(keepPositions)
+            )
+        }
+
+    /** Alle Runden eines Boots - beim Zurücksetzen eines Laufs. */
     fun deleteByTeam(teamId: UUID) = COMPETITION_MATCH_TEAM_LAP.delete { COMPETITION_MATCH_TEAM.eq(teamId) }
 
     fun getByTeams(teamIds: List<UUID>) = COMPETITION_MATCH_TEAM_LAP.select { COMPETITION_MATCH_TEAM.`in`(teamIds) }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/CompetitionMatchTeamDto.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/CompetitionMatchTeamDto.kt
@@ -40,6 +40,13 @@ data class MatchTeamLapDto(
     val name: String,
     val timeString: String,
     val recordedAt: LocalDateTime? = null,
+    /**
+     * Die gefahrene Zeit als Zahl - reine Sortierhilfe des Rundenbands, angezeigt wird
+     * [timeString]. Trifft im selben Abruf mehreres ein, tragen die Marken denselben
+     * [recordedAt]; dann ist die höhere Zeit die jüngere Nachricht, weil dieses Boot später an
+     * der Marke war.
+     */
+    val lapMillis: Long? = null,
 )
 
 /**
@@ -56,4 +63,5 @@ fun matchTeamLapDto(name: String, lapMillis: Long, recordedAt: LocalDateTime? = 
         millisecondPrecision = Timecode.MillisecondPrecision.ONE,
     ).toString(),
     recordedAt = recordedAt,
+    lapMillis = lapMillis,
 )

--- a/backend/src/main/resources/openapi/documentation.yaml
+++ b/backend/src/main/resources/openapi/documentation.yaml
@@ -14277,6 +14277,14 @@ components:
           format: date-time
           nullable: true
           description: "when the lap time arrived; carries the ordering of the stream lap band"
+        lapMillis:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            Elapsed time at this mark in milliseconds - a sorting aid for the lap band only, the
+            display uses timeString. Marks arriving in the same poll share recordedAt; the higher
+            time is then the more recent news.
 
     UpdateCompetitionMatchRequest:
       type: object

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2626,6 +2626,10 @@ export type MatchTeamLapDto = {
      * when the lap time arrived; carries the ordering of the stream lap band
      */
     recordedAt?: string | null
+    /**
+     * Elapsed time at this mark in milliseconds - a sorting aid for the lap band only, the display uses timeString. Marks arriving in the same poll share recordedAt; the higher time is then the more recent news.
+     */
+    lapMillis?: number | null
 }
 
 /**

--- a/frontend/src/components/event/board/streamOverlay.test.ts
+++ b/frontend/src/components/event/board/streamOverlay.test.ts
@@ -22,9 +22,10 @@ const lap = (
     name: string,
     timeString: string,
     recordedAt: string | null,
+    lapMillis?: number,
 ): {startNumber: number; laps: MatchTeamLapDto[]} => ({
     startNumber,
-    laps: [{name, timeString, recordedAt}] as MatchTeamLapDto[],
+    laps: [{name, timeString, recordedAt, lapMillis}] as MatchTeamLapDto[],
 })
 
 const runningMatch = (teams: ReturnType<typeof lap>[]) =>
@@ -167,14 +168,44 @@ describe('lastLaps', () => {
         expect(laps.map(l => l.startNumber)).toEqual([2, 3, 1])
     })
 
-    it('Runden ohne recordedAt landen hinten, stabil nach Rundenname und Startnummer', () => {
+    it('Runden ohne recordedAt landen hinten, die spätere Marke davon zuerst', () => {
+        // Ohne Zeitstempel entscheidet die Marke: "Runde 2" ist die jüngere Nachricht als
+        // "Runde 1". Bis zum 15.08.2026 sortierte die Liste hier AUFSTEIGEND nach Namen und
+        // stellte damit die älteste Marke nach vorn.
         const m = runningMatch([
             lap(1, 'Runde 2', '0:30.0', null),
             lap(2, 'Runde 1', '0:31.0', '2026-08-13T10:00:00Z'),
             lap(3, 'Runde 1', '0:32.0', null),
         ])
         const laps = lastLaps(m, 10)
-        expect(laps.map(l => l.startNumber)).toEqual([2, 3, 1])
+        expect(laps.map(l => l.startNumber)).toEqual([2, 1, 3])
+    })
+
+    /**
+     * Der Fehler aus dem Livestream: Der RaceClocker-Abruf schrieb alle Runden eines Boots je
+     * Takt neu und gab ihnen denselben Zeitstempel. Damit hatte die Sortierung nichts zu
+     * sortieren und fiel auf den Rundennamen zurück - im Band standen ewig 1, 2 und 3, nie die
+     * zuletzt eingetroffene Zeit. Der Zeitstempel bleibt jetzt am Datensatz stehen; für
+     * Gleichstand innerhalb eines Takts entscheidet die gefahrene Zeit.
+     */
+    it('bei gleichem Zeitstempel gewinnt die spätere Fahrzeit', () => {
+        const gleich = '2026-08-16T09:00:00Z'
+        const m = runningMatch([
+            lap(1, 'Runde 1', '0:30.0', gleich, 30_000),
+            lap(2, 'Runde 2', '1:05.0', gleich, 65_000),
+            lap(3, 'Runde 3', '1:40.0', gleich, 100_000),
+        ])
+        expect(lastLaps(m).map(l => l.lapName)).toEqual(['Runde 3', 'Runde 2', 'Runde 1'])
+    })
+
+    it('ein echter Zeitstempel schlägt die Fahrzeit', () => {
+        // Trifft eine frühe Marke eines langsameren Boots später ein, ist sie die jüngere
+        // Nachricht - der Eingang zählt, nicht die Streckenposition.
+        const m = runningMatch([
+            lap(1, 'Runde 3', '1:40.0', '2026-08-16T09:00:00Z', 100_000),
+            lap(2, 'Runde 1', '0:35.0', '2026-08-16T09:00:30Z', 35_000),
+        ])
+        expect(lastLaps(m).map(l => l.startNumber)).toEqual([2, 1])
     })
 
     it('begrenzt standardmäßig auf drei Einträge', () => {

--- a/frontend/src/components/event/board/streamOverlay.ts
+++ b/frontend/src/components/event/board/streamOverlay.ts
@@ -26,6 +26,12 @@ export type StreamLapEntry = {
     lapName: string
     timeString: string
     recordedAt: string | null
+    /**
+     * Gefahrene Zeit an dieser Marke in Millisekunden - nur zum Sortieren, nicht zum Anzeigen
+     * (dafür ist [timeString] da). Trifft mehreres im selben Takt ein, ist die höhere Zeit die
+     * jüngere Nachricht: Dieses Boot war später an der Marke.
+     */
+    lapMillis: number | null
 }
 
 /** Chroma-Voreinstellung des Stream-Overlays — reines Grün. */
@@ -61,6 +67,7 @@ export const lastLaps = (match: AthleteBoardMatch, limit = 3): StreamLapEntry[] 
             lapName: lap.name,
             timeString: lap.timeString,
             recordedAt: lap.recordedAt ?? null,
+            lapMillis: lap.lapMillis ?? null,
         })),
     )
 
@@ -72,7 +79,14 @@ export const lastLaps = (match: AthleteBoardMatch, limit = 3): StreamLapEntry[] 
             if (ta !== null && tb !== null && ta !== tb) return tb - ta // neueste zuerst
             if (ta !== null && tb === null) return -1 // Runde mit Zeit vor Runde ohne
             if (ta === null && tb !== null) return 1
-            const nameCompare = a.lapName.localeCompare(b.lapName)
+            // Gleicher Zeitstempel heißt: im selben Takt eingetroffen. Dann entscheidet die
+            // gefahrene Zeit - wer später an der Marke war, ist die jüngere Nachricht. Der
+            // Rundenname taugt dafür nicht: nach ihm stand ewig 1, 2, 3 im Band, weil der
+            // Abruf früher alle Runden mit demselben Zeitstempel neu schrieb.
+            if (a.lapMillis != null && b.lapMillis != null && a.lapMillis !== b.lapMillis) {
+                return b.lapMillis - a.lapMillis
+            }
+            const nameCompare = b.lapName.localeCompare(a.lapName, undefined, {numeric: true})
             if (nameCompare !== 0) return nameCompare
             return a.startNumber - b.startNumber
         })

--- a/frontend/src/components/event/board/streamOverlay/LapBand.tsx
+++ b/frontend/src/components/event/board/streamOverlay/LapBand.tsx
@@ -9,14 +9,20 @@ interface LapBandProps {
     element: BoardElement
 }
 
-/** Startversatz eines neu eintreffenden Rundeneintrags — schiebt sichtbar von rechts herein. */
-const LAP_ENTER_OFFSET = 260
+/**
+ * Startversatz eines neu eintreffenden Rundeneintrags. NEGATIV: Der neue Eintrag kommt von links
+ * herein und schiebt die älteren nach rechts aus dem Band - dieselbe Richtung, in der die Zeiten
+ * gedanklich eintreffen. Vorher kam er von rechts hereingefahren und lief damit gegen die
+ * Leserichtung der Reihe (neueste links).
+ */
+const LAP_ENTER_OFFSET = -260
 
 /**
  * Modus „Rundenanzeige": schmales Bauchband unten (~10 vh), bis zu drei zuletzt
  * eingetroffene Rundenzeiten nebeneinander — neueste links, mit Akzentrand. Eine neue
- * Rundenzeit schiebt per translateX-FLIP von rechts herein, die übrigen rücken nach
- * (FlipList mit axis="x" übernimmt beides über dieselbe Positionsmessung).
+ * Rundenzeit schiebt per translateX-FLIP von links herein, die übrigen rücken nach rechts
+ * und die älteste fällt hinten heraus (FlipList mit axis="x" übernimmt beides über dieselbe
+ * Positionsmessung).
  */
 const LapBand = ({laps, element}: LapBandProps) => {
     const theme = useTheme()
@@ -44,7 +50,11 @@ const LapBand = ({laps, element}: LapBandProps) => {
                     axis="x"
                     enterOffset={LAP_ENTER_OFFSET}
                     items={laps}
-                    keyOf={lap => `${lap.startNumber}-${lap.lapName}-${lap.recordedAt ?? ''}`}
+                    // Der Schlüssel darf den Erfassungszeitpunkt NICHT enthalten: Solange der Abruf
+                    // ihn je Takt neu vergab, galt jede Runde bei jedem Takt als neuer Eintrag und
+                    // das Band animierte im Sekundentakt durch. Boot und Marke identifizieren die
+                    // Zeile eindeutig.
+                    keyOf={lap => `${lap.startNumber}-${lap.lapName}`}
                     // `flex`/`minWidth` müssen auf FlipLists Wrapper-<div> sitzen — das ist
                     // das tatsächliche Flex-Item der Stack-Row, nicht diese innere Box.
                     itemStyle={{flex: '1 1 0', minWidth: '16rem'}}


### PR DESCRIPTION
Folge zu #105.

Das Rundenband des Livestream-Overlays zeigte immer dieselben drei Runden — 1, 2, 3 — und nie die zuletzt eingetroffene Zeit.

## Ursache

Der RaceClocker-Abruf löschte je Takt **alle** Runden eines Boots und schrieb sie neu, mit `created_at = now`. Damit trugen sämtliche Runden denselben, bei jedem Takt frischen Zeitstempel. Die Sortierung „zuletzt eingetroffen zuerst" hatte nichts zu sortieren und fiel auf den Rundennamen zurück — aufsteigend, also 1, 2, 3.

## Änderung

- **Der Abruf schreibt per Upsert** über den eindeutigen Index (Boot, Position) und lässt `created_at` stehen; Marken, die der Feed nicht mehr führt, werden entfernt. Der Zeitstempel bedeutet damit, was sein Name sagt: wann diese Marke zum ersten Mal da war.
- **Gleichstand innerhalb eines Takts** entscheidet die gefahrene Zeit (neu im DTO als `lapMillis`, reine Sortierhilfe — angezeigt wird weiterhin `timeString`): Wer später an der Marke war, ist die jüngere Nachricht. Ohne Zeitstempel entscheidet die Marke selbst, absteigend.
- **Einlaufrichtung:** Ein neuer Eintrag kommt von links herein und schiebt die älteren nach rechts aus dem Band, statt gegen die Leserichtung von rechts hereinzufahren.
- **Listenschlüssel ohne Erfassungszeitpunkt:** Solange der Abruf ihn je Takt neu vergab, galt jede Runde bei jedem Takt als neuer Eintrag — das Band animierte im Sekundentakt durch.

Ein bestehender Test kodierte für Runden ohne Zeitstempel die umgekehrte Reihenfolge („Runde 1" vor „Runde 2"); er ist mitkorrigiert. Zwei Fälle kommen dazu, die den Fehler festhalten.

Keine Migration.

## Stand der Prüfung

Backend 1108 Tests, Frontend 1232 Tests, `tsc -b` grün.
