### PR TITLE
Nennung der Zeitnahme auf den öffentlichen Ergebnissen

### DIFF
--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
@@ -751,7 +751,24 @@ object CompetitionExecutionService {
      */
     private fun prepareForNewPlaces(
         matchId: UUID,
+        userId: UUID,
+        timing: TimingAttribution?,
     ): App<Nothing, Unit> = KIO.comprehension {
+
+        // Hält fest, wessen Zeitnahme die Ergebnisse dieses Laufs zuletzt geliefert hat - die
+        // Nennung auf den öffentlichen Ergebnissen hängt daran. `activated_at`/`currently_running`
+        // bleiben unberührt - siehe Erklärung oben. Geschrieben wird nur bei echter Änderung: Der
+        // automatische RaceClocker-Abruf läuft im Sekundentakt durch diese Funktion, und ein
+        // `updated_at` bei jedem Takt würde die „zuletzt aktualisiert"-Reihenfolge der
+        // öffentlichen Ergebnisse durcheinanderbringen.
+        !CompetitionMatchRepo.update(matchId) {
+            if (timingProviderName != timing?.name || timingProviderUrl != timing?.url) {
+                timingProviderName = timing?.name
+                timingProviderUrl = timing?.url
+                updatedBy = userId
+                updatedAt = LocalDateTime.now()
+            }
+        }.orDie()
 
         !CompetitionMatchTeamRepo.updateManyByMatch(matchId) {
             place = null
@@ -802,7 +819,7 @@ object CompetitionExecutionService {
         !checkUpdateMatchResult(competitionId, matchId)
         !pauseRaceClockerAutoPull(matchId)
 
-        !prepareForNewPlaces(matchId)
+        !prepareForNewPlaces(matchId, userId, timing = null)
 
         val noPlaces = request.teamResults.filter { !it.failed }.any { it.place == null }
 
@@ -928,7 +945,6 @@ object CompetitionExecutionService {
 
         val match = !checkUpdateMatchResult(competitionId, matchId)
         !pauseRaceClockerAutoPull(matchId)
-        !prepareForNewPlaces(matchId)
 
         // Das Format gehoert zum Wettkampf (Zeitnahme-Tab), nicht mehr zur einzelnen Anfrage --
         // und der Wettkampf erbt es von der Veranstaltung, solange er selbst keines gesetzt hat
@@ -942,6 +958,8 @@ object CompetitionExecutionService {
         }
         val config = !MatchResultImportConfigRepo.get(configId).orDie()
             .onNullFail { MatchResultImportConfigError.NotFound }
+
+        !prepareForNewPlaces(matchId, userId, timing = TimingAttribution.of(config.attributionName, config.attributionUrl))
 
         val identifierColumn = config.colTeamRegistrationId
 
@@ -1365,7 +1383,8 @@ object CompetitionExecutionService {
             }.orDie()
         }
 
-        !prepareForNewPlaces(matchId)
+        // Die Ergebnisse dieses Laufs kommen aus RaceClocker - die Nennung steht damit fest.
+        !prepareForNewPlaces(matchId, userId, timing = TimingAttribution.RACECLOCKER)
 
         val parsed = withResult.map { (registrationId, row) ->
             ParsedTeamResult(

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/CompetitionMatchRepo.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/CompetitionMatchRepo.kt
@@ -245,6 +245,9 @@ object CompetitionMatchRepo {
             COMPETITION_VIEW.NAME.`as`("competition_name"),
             COMPETITION_VIEW.CATEGORY_NAME,
             COMPETITION_VIEW.SHORT_NAME,
+            // Nennung der Zeitnahme, wie sie beim Schreiben der Ergebnisse am Lauf abgelegt wurde.
+            COMPETITION_MATCH.TIMING_PROVIDER_NAME,
+            COMPETITION_MATCH.TIMING_PROVIDER_URL,
         )
             .from(COMPETITION_MATCH)
             .join(COMPETITION_SETUP_MATCH)

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TimingAttribution.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TimingAttribution.kt
@@ -1,0 +1,28 @@
+package de.lambda9.ready2race.backend.app.competitionExecution.entity
+
+/**
+ * Die Nennung der externen Zeitnahme, die auf den öffentlichen Ergebnissen eines Laufs steht.
+ *
+ * Anbieter verlangen sie in ihren Nutzungsbedingungen (RaceClocker Nr. 6): Wer ihre Zeiten
+ * veröffentlicht, nennt sie sichtbar und verlinkt sie. Die Nennung wird beim Schreiben der
+ * Ergebnisse am Lauf abgelegt (Abzug, kein Verweis) - siehe V202608201200.
+ */
+data class TimingAttribution(
+    val name: String,
+    val url: String?,
+) {
+    companion object {
+
+        /**
+         * Der Live-Abruf holt seine Ergebnisse direkt aus RaceClocker und kennt keine
+         * Import-Konfiguration, an der eine Nennung gepflegt wäre. Für ihn steht sie hier.
+         */
+        val RACECLOCKER = TimingAttribution("RaceClocker", "https://raceclocker.com")
+
+        /**
+         * Die Nennung einer Import-Konfiguration - `null`, solange dort keine gepflegt ist.
+         */
+        fun of(name: String?, url: String?): TimingAttribution? =
+            name?.takeIf { it.isNotBlank() }?.let { TimingAttribution(it, url?.takeIf { u -> u.isNotBlank() }) }
+    }
+}

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventInfo/boundary/EventInfoService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventInfo/boundary/EventInfoService.kt
@@ -111,6 +111,8 @@ object EventInfoService {
                 updatedAt = match[COMPETITION_MATCH.UPDATED_AT]!!,
                 startTime = match[COMPETITION_MATCH.START_TIME],
                 startedAt = match[COMPETITION_MATCH.STARTED_AT],
+                timingProviderName = match[COMPETITION_MATCH.TIMING_PROVIDER_NAME],
+                timingProviderUrl = match[COMPETITION_MATCH.TIMING_PROVIDER_URL],
                 teams = teams
             )
         }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventInfo/entity/LatestMatchResultInfo.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/eventInfo/entity/LatestMatchResultInfo.kt
@@ -20,6 +20,9 @@ data class LatestMatchResultInfo(
     val startTime: LocalDateTime?,
     /** Tatsächlicher Start aus `competition_match.started_at`, falls gestempelt. */
     val startedAt: LocalDateTime?,
+    /** Nennung der externen Zeitnahme, falls die Ergebnisse von dort kamen. */
+    val timingProviderName: String?,
+    val timingProviderUrl: String?,
     val teams: List<MatchResultTeamInfo>
 )
 

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/boundary/MatchResultImportConfigService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/boundary/MatchResultImportConfigService.kt
@@ -62,6 +62,8 @@ object MatchResultImportConfigService {
             colTeamRegistrationId = request.colTeamRegistrationId
             colTeamPlace = request.colTeamPlace
             colTeamTime = request.colTeamTime
+            attributionName = request.attributionName
+            attributionUrl = request.attributionUrl
             updatedAt = LocalDateTime.now()
             updatedBy = userId
         }.orDie()

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/control/Conversions.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/control/Conversions.kt
@@ -20,6 +20,8 @@ fun MatchResultImportConfigRequest.toRecord(userId: UUID): App<Nothing, MatchRes
             colTeamRegistrationId = colTeamRegistrationId,
             colTeamPlace = colTeamPlace,
             colTeamTime = colTeamTime,
+            attributionName = attributionName,
+            attributionUrl = attributionUrl,
             createdAt = now,
             createdBy = userId,
             updatedAt = now,
@@ -36,5 +38,7 @@ fun MatchResultImportConfigRecord.toDto(): App<Nothing, MatchResultImportConfigD
         colTeamRegistrationId = colTeamRegistrationId,
         colTeamPlace = colTeamPlace,
         colTeamTime = colTeamTime,
+        attributionName = attributionName,
+        attributionUrl = attributionUrl,
     )
 )

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/entity/MatchResultImportConfigDto.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/entity/MatchResultImportConfigDto.kt
@@ -9,4 +9,6 @@ data class MatchResultImportConfigDto(
     val colTeamRegistrationId: String,
     val colTeamPlace: String?,
     val colTeamTime: String?,
+    val attributionName: String?,
+    val attributionUrl: String?,
 )

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/entity/MatchResultImportConfigRequest.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/matchResultImportConfig/entity/MatchResultImportConfigRequest.kt
@@ -13,6 +13,8 @@ data class MatchResultImportConfigRequest(
     val colTeamRegistrationId: String,
     val colTeamPlace: String,
     val colTeamTime: String,
+    val attributionName: String?,
+    val attributionUrl: String?,
 ) : Validatable {
     override fun validate(): ValidationResult =
         ValidationResult.allOf(
@@ -30,6 +32,8 @@ data class MatchResultImportConfigRequest(
             colTeamRegistrationId = "Info 1",
             colTeamPlace = "Place",
             colTeamTime = "2:31",
+            attributionName = "Webscorer",
+            attributionUrl = "https://www.webscorer.com",
         )
     }
 }

--- a/backend/src/main/resources/db/migration/V202608201200__timing_provider_attribution.sql
+++ b/backend/src/main/resources/db/migration/V202608201200__timing_provider_attribution.sql
@@ -1,0 +1,55 @@
+set search_path to ready2race, pg_catalog, public;
+
+-- Nennung der externen Zeitnahme auf den öffentlichen Ergebnissen.
+--
+-- Anbieter von Zeitnahme verlangen einen sichtbaren Hinweis samt Link, wenn ihre Daten
+-- veröffentlicht werden (RaceClocker, Nutzungsbedingungen Nr. 6). Woher die Ergebnisse eines
+-- Laufs zuletzt kamen, steht deshalb am Lauf selbst -- als Abzug (Name + Website) und nicht als
+-- Verweis auf die Import-Konfiguration: Der RaceClocker-Abruf holt seine Ergebnisse ohne eine
+-- solche Konfiguration (eigene `raceclocker_race`-Tabellen), und ein veröffentlichter Hinweis
+-- soll auch dann stehen bleiben, wenn die Konfiguration später umbenannt oder gelöscht wird.
+
+alter table match_result_import_config
+    add column attribution_name text,
+    add column attribution_url text;
+
+update match_result_import_config
+    set attribution_name = 'RaceClocker',
+        attribution_url = 'https://raceclocker.com'
+    where name ilike '%raceclocker%';
+
+update match_result_import_config
+    set attribution_name = 'Webscorer',
+        attribution_url = 'https://www.webscorer.com'
+    where name ilike '%webscorer%';
+
+alter table competition_match
+    add column timing_provider_name text,
+    add column timing_provider_url  text;
+
+-- Bestandsdaten: Läufe, deren Ergebnisse schon aus RaceClocker kamen, bekommen die Nennung
+-- nachgetragen - sonst stünde sie ausgerechnet unter den bereits veröffentlichten Ergebnissen
+-- nicht. Woher ein Ergebnis kam, ist rückwirkend nicht aufgezeichnet; erkannt wird es an drei
+-- Zeichen zusammen: Der Wettkampf misst mit RaceClocker, hat ein Rennen angewählt, und der Lauf
+-- wurde entweder abgerufen (`raceclocker_polled_at`, der Automatik-Stempel) oder trägt
+-- Ergebnisse. Ausgenommen sind Läufe mit angehaltener Automatik: Genau dort hat jemand von Hand
+-- eingetragen oder eine Datei hochgeladen, die Zeiten stammen also nicht aus RaceClocker.
+update competition_match cm
+set timing_provider_name = 'RaceClocker',
+    timing_provider_url  = 'https://raceclocker.com'
+from competition_setup_match csm
+    join competition_setup_round csr on csm.competition_setup_round = csr.id
+    join competition_properties cp on csr.competition_setup = cp.id
+    join competition c on cp.competition = c.id
+    join event e on c.event = e.id
+where cm.competition_setup_match = csm.id
+  and c.raceclocker_race is not null
+  and coalesce(c.timing_system, e.timing_system) = 'RACECLOCKER'
+  and cm.raceclocker_auto_paused_at is null
+  and (
+    cm.raceclocker_polled_at is not null
+        or exists (select 1
+                   from competition_match_team cmt
+                   where cmt.competition_match = cm.competition_setup_match
+                     and cmt.place is not null)
+    );

--- a/backend/src/main/resources/openapi/documentation.yaml
+++ b/backend/src/main/resources/openapi/documentation.yaml
@@ -15651,6 +15651,12 @@ components:
           format: date-time
           nullable: true
           description: "real start, if stamped"
+        timingProviderName:
+          type: string
+          nullable: true
+        timingProviderUrl:
+          type: string
+          nullable: true
         teams:
           type: array
           items:
@@ -17877,6 +17883,12 @@ components:
           type: string
         colTeamTime:
           type: string
+        attributionName:
+          type: string
+          description: Display name of the external timing provider, shown with a reference link on public result views (e.g. "RaceClocker").
+        attributionUrl:
+          type: string
+          description: Website of the external timing provider the public attribution links to.
 
     MatchResultImportConfigDto:
       type: object
@@ -17897,6 +17909,10 @@ components:
         colTeamPlace:
           type: string
         colTeamTime:
+          type: string
+        attributionName:
+          type: string
+        attributionUrl:
           type: string
 
     EventInvoicesInfoDto:

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2218,6 +2218,8 @@ export type LatestMatchResultInfo = {
      * real start, if stamped
      */
     startedAt?: string | null
+    timingProviderName?: string | null
+    timingProviderUrl?: string | null
     teams: Array<MatchResultTeamInfo>
 }
 
@@ -2520,6 +2522,8 @@ export type MatchResultImportConfigDto = {
     colTeamRegistrationId: string
     colTeamPlace?: string
     colTeamTime?: string
+    attributionName?: string
+    attributionUrl?: string
 }
 
 export type MatchResultImportConfigRequest = {
@@ -2531,6 +2535,14 @@ export type MatchResultImportConfigRequest = {
     colTeamRegistrationId: string
     colTeamPlace?: string
     colTeamTime?: string
+    /**
+     * Display name of the external timing provider, shown with a reference link on public result views (e.g. "RaceClocker").
+     */
+    attributionName?: string
+    /**
+     * Website of the external timing provider the public attribution links to.
+     */
+    attributionUrl?: string
 }
 
 export type MatchResultTeamInfo = {

--- a/frontend/src/components/matchResultImportConfig/MatchResultImportConfigDialog.tsx
+++ b/frontend/src/components/matchResultImportConfig/MatchResultImportConfigDialog.tsx
@@ -15,6 +15,8 @@ type Form = {
     colTeamRegistrationId: string
     colTeamPlace?: string
     colTeamTime?: string
+    attributionName: string
+    attributionUrl: string
 }
 
 const defaultValues: Form = {
@@ -23,6 +25,8 @@ const defaultValues: Form = {
     colTeamRegistrationId: '',
     colTeamPlace: '',
     colTeamTime: '',
+    attributionName: '',
+    attributionUrl: '',
 }
 
 const addAction = (formData: Form) =>
@@ -90,6 +94,15 @@ const MatchResultImportConfigDialog = (
                         },
                     }}
                 />
+                <FormInputText
+                    name={'attributionName'}
+                    label={t('configuration.import.matchResult.attribution.name')}
+                    helperText={t('configuration.import.matchResult.attribution.hint')}
+                />
+                <FormInputText
+                    name={'attributionUrl'}
+                    label={t('configuration.import.matchResult.attribution.url')}
+                />
             </Stack>
         </EntityDialog>
     )
@@ -101,6 +114,8 @@ const mapFormToRequest = (formData: Form): MatchResultImportConfigRequest => ({
     colTeamRegistrationId: formData.colTeamRegistrationId,
     colTeamPlace: formData.colTeamPlace,
     colTeamTime: formData.colTeamTime,
+    attributionName: takeIfNotEmpty(formData.attributionName),
+    attributionUrl: takeIfNotEmpty(formData.attributionUrl),
 })
 
 const mapDtoToForm = (dto: MatchResultImportConfigDto): Form => ({
@@ -109,6 +124,8 @@ const mapDtoToForm = (dto: MatchResultImportConfigDto): Form => ({
     colTeamRegistrationId: dto.colTeamRegistrationId ?? '',
     colTeamPlace: dto.colTeamPlace,
     colTeamTime: dto.colTeamTime,
+    attributionName: dto.attributionName ?? '',
+    attributionUrl: dto.attributionUrl ?? '',
 })
 
 export default MatchResultImportConfigDialog

--- a/frontend/src/components/results/MatchResults.tsx
+++ b/frontend/src/components/results/MatchResults.tsx
@@ -8,6 +8,7 @@ import {CompetitionChoiceDto, EventNoticeDto, LatestMatchResultInfo} from '@api/
 import ResultsMatchDialog from '@components/results/ResultsMatchDialog.tsx'
 import ResultsMatchCard from '@components/results/ResultsMatchCard.tsx'
 import EventNoticeBanner from '@components/eventNotice/EventNoticeBanner.tsx'
+import TimingProviderAttribution from '@components/results/TimingProviderAttribution.tsx'
 
 type Props = {
     eventId: string
@@ -241,6 +242,7 @@ const MatchResults = ({
                                     key={match.matchId}
                                 />
                             ))}
+                        <TimingProviderAttribution matches={matchResultsData ?? []} />
                     </>
                 )}
             </Stack>

--- a/frontend/src/components/results/ResultsMatchDialog.tsx
+++ b/frontend/src/components/results/ResultsMatchDialog.tsx
@@ -25,6 +25,7 @@ import {sortByPlaces, compareNullsHigh} from '@utils/helpers.ts'
 import {groupByRatingCategory, hasRatingCategories} from '@utils/ratingCategorySections.ts'
 import {failedLabel} from '@utils/matchResultStatus.ts'
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
+import TimingProviderAttribution from '@components/results/TimingProviderAttribution.tsx'
 
 type Props<M extends ResultsMatchInfo> = {
     match: M | null
@@ -276,6 +277,9 @@ const ResultsMatchDialog = <M extends ResultsMatchInfo>({
                                     ))}
                                 </Stack>
                             ))}
+                            {'timingProviderName' in match && (
+                                <TimingProviderAttribution matches={[match]} />
+                            )}
                         </Stack>
                     </DialogContent>
                     <DialogActions>

--- a/frontend/src/components/results/TimingProviderAttribution.tsx
+++ b/frontend/src/components/results/TimingProviderAttribution.tsx
@@ -1,0 +1,58 @@
+import {Link, Stack, Typography} from '@mui/material'
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
+import {useTranslation} from 'react-i18next'
+
+type TimingProviderSource = {
+    timingProviderName?: string | null
+    timingProviderUrl?: string | null
+}
+
+type Props = {
+    matches: TimingProviderSource[]
+}
+
+// Attribution of the external timing provider (e.g. RaceClocker) whose terms require a visible
+// reference/link wherever their timing data is published.
+const TimingProviderAttribution = ({matches}: Props) => {
+    const {t} = useTranslation()
+
+    const providers = [
+        ...new Map(
+            matches
+                .filter(match => match.timingProviderName)
+                .map(match => [match.timingProviderName!, match.timingProviderUrl ?? null]),
+        ).entries(),
+    ]
+
+    if (providers.length === 0) {
+        return null
+    }
+
+    return (
+        <Stack
+            direction={'row'}
+            spacing={0.5}
+            justifyContent={'center'}
+            alignItems={'center'}
+            sx={{py: 1}}>
+            <TimerOutlinedIcon color={'action'} fontSize={'inherit'} />
+            <Typography variant={'body2'} color={'textSecondary'}>
+                {t('results.timing.attribution')}{' '}
+                {providers.map(([name, url], index) => (
+                    <span key={name}>
+                        {index > 0 && ', '}
+                        {url ? (
+                            <Link href={url} target={'_blank'} rel={'noopener noreferrer'}>
+                                {name}
+                            </Link>
+                        ) : (
+                            name
+                        )}
+                    </span>
+                ))}
+            </Typography>
+        </Stack>
+    )
+}
+
+export default TimingProviderAttribution

--- a/frontend/src/i18n/da/translations.json
+++ b/frontend/src/i18n/da/translations.json
@@ -2604,6 +2604,11 @@
         },
         "error": {
           "noPlaceOrTime": "Angiv venligst kolonnen for placeringer eller tider."
+        },
+        "attribution": {
+          "name": "Tidtagningsudbyder (kreditering)",
+          "url": "Tidtagningsudbyderens websted",
+          "hint": "Vises som en henvisning med link på de offentlige resultater, når resultater er importeret med denne konfiguration."
         }
       }
     },
@@ -2945,6 +2950,9 @@
     },
     "individualRanking": {
       "error": "Fejl ved indlæsning af individuel rangliste"
+    },
+    "timing": {
+      "attribution": "Tidtagning af"
     },
     "noResults": "Ingen resultater",
     "challengeTabs": {

--- a/frontend/src/i18n/de/translations.json
+++ b/frontend/src/i18n/de/translations.json
@@ -2617,6 +2617,11 @@
         },
         "error": {
           "noPlaceOrTime": "Bitte geben Sie die Spalte für Plätze oder Zeiten an."
+        },
+        "attribution": {
+          "name": "Zeitmessungsanbieter (Attribution)",
+          "url": "Website des Zeitmessungsanbieters",
+          "hint": "Wird als Verweis mit Link in den öffentlichen Ergebnissen angezeigt, wenn Ergebnisse mit dieser Konfiguration importiert wurden."
         }
       }
     },
@@ -2958,6 +2963,9 @@
     },
     "individualRanking": {
       "error": "Fehler beim Laden der Individualrangliste"
+    },
+    "timing": {
+      "attribution": "Zeitmessung durch"
     },
     "noResults": "Keine Ergebnisse",
     "challengeTabs": {

--- a/frontend/src/i18n/en/translations.json
+++ b/frontend/src/i18n/en/translations.json
@@ -2617,6 +2617,11 @@
         },
         "error": {
           "noPlaceOrTime": "Please specify at least the place or time column."
+        },
+        "attribution": {
+          "name": "Timing provider (attribution)",
+          "url": "Timing provider website",
+          "hint": "Shown as a reference with link on the public results whenever results were imported with this configuration."
         }
       }
     },
@@ -2958,6 +2963,9 @@
     },
     "individualRanking": {
       "error": "Error loading individual rankings"
+    },
+    "timing": {
+      "attribution": "Timing by"
     },
     "noResults": "No results",
     "challengeTabs": {


### PR DESCRIPTION
RaceClocker verlangt in seinen Nutzungsbedingungen (Nr. 6) einen sichtbaren Hinweis mit Link, wo seine Zeiten veröffentlicht werden. Bisher steht der nirgends.

## Was drin ist

- `competition_match` hält fest, wessen Zeitnahme die Ergebnisse zuletzt geliefert hat — als **Abzug** (`timing_provider_name` / `timing_provider_url`), nicht als Verweis auf die Import-Konfiguration. Zwei Gründe: Der RaceClocker-Abruf holt seine Ergebnisse ohne eine solche Konfiguration (eigene `raceclocker_race`-Tabellen), und ein einmal veröffentlichter Hinweis soll auch nach Umbenennung oder Löschen der Konfiguration stehen bleiben.
- Gesetzt wird die Nennung beim Datei-Import aus der Import-Konfiguration und beim RaceClocker-Abruf fest auf RaceClocker. Die **Eingabe von Hand löscht sie** — dort hat nicht mehr die externe Zeitnahme gemessen.
- Geschrieben wird nur bei echter Änderung. Der automatische Abruf läuft im Sekundentakt durch dieselbe Funktion; ein `updated_at` bei jedem Takt hätte die „zuletzt aktualisiert"-Reihenfolge der öffentlichen Ergebnisse verstellt.
- `match_result_import_config` bekommt `attribution_name` / `attribution_url`, im Konfigurationsdialog pflegbar und für Konfigurationen mit „RaceClocker" oder „Webscorer" im Namen vorbelegt.
- Angezeigt wird „Zeitmessung durch <Anbieter>" mit Link in der öffentlichen Ergebnisliste und im Lauf-Dialog (de/en/da).

## Migration `V202608201200`

Neben den Spalten trägt sie die Nennung für **Bestandsläufe** nach, sonst stünde sie ausgerechnet unter den bereits veröffentlichten Ergebnissen nicht. Woher ein Ergebnis kam, ist rückwirkend nicht aufgezeichnet; erkannt wird es an drei Zeichen zusammen: Der Wettkampf misst mit RaceClocker, hat ein Rennen angewählt, und der Lauf wurde abgerufen oder trägt Ergebnisse. Ausgenommen sind Läufe mit angehaltener Automatik — genau dort wurde von Hand eingetragen.

Das ist eine Heuristik. Vor dem Deploy lohnt ein Blick, wie viele Zeilen sie in der Produktion trifft.

## Geprüft

`./mvnw test` (1108 grün), `npm run build` und `npm test` (1232 grün) gegen den aktuellen `main`.

## Offen

Die Boards zeigen die Nennung nicht — sie veröffentlichen Ergebnisse ebenfalls. Falls das für die Nutzungsbedingungen zählt, wäre das ein Nachtrag.