### PR TITLE
Wertung je Partie: Finale A, B und C haben je einen Ersten

### DIFF
--- a/api/src/competitionExecution.tsp
+++ b/api/src/competitionExecution.tsp
@@ -47,6 +47,8 @@ model CompetitionTeamPlaceDto {
   clubName: string;
   namedParticipants: CompetitionTeamNamedParticipantDto[];
   place: int32;
+  /** Name of the match the place was scored in. Only set when the round scores places separately per match. */
+  matchName?: string;
   deregistered: boolean;
   deregistrationReason?: string;
 }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
@@ -2115,7 +2115,7 @@ object CompetitionExecutionService {
 
     fun computeCompetitionPlaces(
         competitionId: UUID,
-    ): App<ServiceError, List<Pair<CompetitionMatchTeamWithRegistration, Int>>> = KIO.comprehension {
+    ): App<ServiceError, List<TeamPlacement>> = KIO.comprehension {
         val setupRoundRecords = !CompetitionSetupService.getSetupRoundsWithMatches(competitionId)
 
         KIO.ok(computeCompetitionPlaces(sortRounds(setupRoundRecords)))
@@ -2132,7 +2132,7 @@ object CompetitionExecutionService {
      */
     fun computeCompetitionPlaces(
         setupRounds: List<CompetitionSetupRoundWithMatches>,
-    ): List<Pair<CompetitionMatchTeamWithRegistration, Int>> {
+    ): List<TeamPlacement> {
 
         val roundsWithTeamsToPlaces =
             setupRounds.filterIndexed { roundIdx, round -> // filters out rounds for which there was no following round created yet
@@ -2186,20 +2186,39 @@ object CompetitionExecutionService {
 
                     val teamToPlace = when (round.placesOption) {
                         CompetitionSetupPlacesOption.EQUAL.name -> {
-                            team to if (!isLastRound) {
+                            val place = if (!isLastRound) {
                                 setupRounds[roundIdx + 1].matches.flatMap { m -> m.teams.toList() }.size + 1 // Place is one higher than the count of participants in the next round
                             } else 1 // 1 if this is the final round
+                            TeamPlacement(team, place, null, null)
                         }
 
                         CompetitionSetupPlacesOption.ASCENDING.name ->
-                            team to getRoundOutcome(seedingList!!, matchIndex, realPlace)
+                            TeamPlacement(team, getRoundOutcome(seedingList!!, matchIndex, realPlace))
+
+                        // Jede Partie wird für sich gewertet: Finale A, B und C haben jeweils einen
+                        // Ersten. Der Platz ist also der Platz IN DER PARTIE, und die Partie gehört
+                        // zur Aussage dazu - ohne sie stünden mehrere „1" nebeneinander, ohne dass
+                        // sich sagen ließe, woher sie kommen.
+                        CompetitionSetupPlacesOption.PER_MATCH.name -> {
+                            val setupMatch = round.setupMatches
+                                .firstOrNull { it.id == sortedRoundMatches[matchIndex].competitionSetupMatch }
+                            TeamPlacement(
+                                team = team,
+                                place = realPlace,
+                                matchName = setupMatch?.name,
+                                matchWeighting = setupMatch?.weighting,
+                            )
+                        }
 
                         else -> {
                             val roundOutcome = getRoundOutcome(seedingList!!, matchIndex, realPlace)
                             // Für ein Massenfeld lässt sich im Setup keine Platztabelle pflegen, weil die
                             // Zahl der Startenden dort erst zur Laufzeit feststeht. Fehlt der Eintrag,
                             // gilt das Rundenergebnis selbst als Platz — wie bei ASCENDING.
-                            team to (round.places.firstOrNull { it.roundOutcome == roundOutcome }?.place ?: roundOutcome)
+                            TeamPlacement(
+                                team,
+                                round.places.firstOrNull { it.roundOutcome == roundOutcome }?.place ?: roundOutcome,
+                            )
                         }
                     }
                     teamToPlace
@@ -2220,6 +2239,8 @@ object CompetitionExecutionService {
         val team: CompetitionMatchTeamWithRegistration,
         val place: Int,
         val categoryPlace: Int?,
+        /** Die Partie, in der der Platz gefahren wurde - nur bei Wertung je Partie gesetzt. */
+        val matchName: String?,
     )
 
     /**
@@ -2232,18 +2253,38 @@ object CompetitionExecutionService {
      * Sie behalten ihren Abschnitt und stehen dort am Ende.
      */
     fun placesByRatingCategory(
-        places: List<Pair<CompetitionMatchTeamWithRegistration, Int>>,
-    ): List<RankedCategory<PlaceInCategory>> =
-        RatingCategoryRanking.groupAndRank(
-            items = places.map { (team, place) -> PlaceInCategory(team, place, null) },
+        places: List<TeamPlacement>,
+    ): List<RankedCategory<PlaceInCategory>> {
+
+        // Der Rang, nach dem geordnet und im Abschnitt durchgezählt wird. Ohne Wertung je Partie
+        // ist das die Reihenfolge der Plätze selbst. Wird je Partie gewertet, sind die Plätze nur
+        // innerhalb ihrer Partie vergleichbar - der Erste aus Finale B steht hinter dem Letzten
+        // aus Finale A, sonst stünden in der Ergebnisliste abwechselnd Erste und Zweite
+        // verschiedener Partien. Gleiche Schlüssel behalten denselben Rang, Gleichstände (etwa aus
+        // EQUAL) bleiben also Gleichstände.
+        val rankByKey = places
+            .map { it.rankKey() }
+            .distinct()
+            .sortedWith(compareBy({ it.first }, { it.second }))
+            .withIndex()
+            .associate { (index, key) -> key to index + 1 }
+
+        val rankByTeam = places.associate { it.team.competitionRegistration to rankByKey.getValue(it.rankKey()) }
+
+        return RatingCategoryRanking.groupAndRank(
+            items = places.map { PlaceInCategory(it.team, it.place, null, it.matchName) },
             category = { it.team.ratingCategory },
-            place = { if (it.team.deregistered || it.team.out || it.team.failed) null else it.place },
+            place = {
+                if (it.team.deregistered || it.team.out || it.team.failed) null
+                else rankByTeam[it.team.competitionRegistration]
+            },
             tieBreak = { it.team.startNumber },
         ).map { section ->
             section.copy(
                 entries = section.entries.map { it.copy(item = it.item.copy(categoryPlace = it.categoryPlace)) }
             )
         }
+    }
 
     fun getCompetitionPlaces(
         eventId: UUID,
@@ -2259,7 +2300,7 @@ object CompetitionExecutionService {
                 // Anzeige gruppiert die flache Liste danach wieder auf.
                 placesByRatingCategory(places)
                     .flatMap { it.entries.map { entry -> entry.item } }
-                    .traverse { it.team.toCompetitionTeamPlaceDto(it.place, it.categoryPlace) }
+                    .traverse { it.team.toCompetitionTeamPlaceDto(it.place, it.categoryPlace, it.matchName) }
             }.map {
                 ApiResponse.ListDto(
                     it
@@ -3160,14 +3201,17 @@ object CompetitionExecutionService {
     }
 
     fun buildCompetitionPlacesCsv(
-        teamsData:  List<Pair<CompetitionMatchTeamWithRegistration, Int>>,
+        teamsData:  List<TeamPlacement>,
         competitionData: EventDataForCompetitionResultsData
     ): ByteArray {
 
         val bytes = ByteArrayOutputStream().use { out ->
             CSV.write(
                 out,
-                teamsData.sortedBy { it.second }
+                // Bei Wertung je Partie kommen die Partien in Setup-Reihenfolge, innerhalb der
+                // Partie nach Platz - sonst stünden abwechselnd Erste und Zweite verschiedener
+                // Partien untereinander. Ohne diese Wertung entscheidet allein der Platz.
+                teamsData.sortedWith(compareBy({ it.matchWeighting ?: 0 }, { it.place }))
             ) {
 
                 column("Veranstaltung") { competitionData.eventName }
@@ -3176,10 +3220,15 @@ object CompetitionExecutionService {
                     column("Veranstaltungsende") { competitionData.eventDateRange.second.format(DateTimeFormatter.ISO_LOCAL_DATE) }
                 }
                 column("Wettkampf") { competitionData.competitionName }
-                column("Platz") { second.toString()}
-                column("Team") { singletonOrFallback(first.participants.map { it.externalClubName }.toSet(), first.mixedTeamTerm)?: first.clubName }
-                column("Anmelder") { first.clubName + if (first.teamNumber != null) " | ${first.teamNumber}" else "" }
-                column("Teammitglieder"){ first.participants.joinToString(", ") { "${it.firstName} ${it.lastName} [${it.namedParticipantName}] (${it.externalClubName?:first.clubName})" }}
+                column("Platz") { place.toString()}
+                // Die Spalte steht nur, wenn es je Lauf gewertete Plätze gibt - sonst trüge sie
+                // in jeder Zeile dasselbe Nichts.
+                if (teamsData.any { it.matchName != null }) {
+                    column("Partie") { matchName ?: "" }
+                }
+                column("Team") { singletonOrFallback(team.participants.map { it.externalClubName }.toSet(), team.mixedTeamTerm)?: team.clubName }
+                column("Anmelder") { team.clubName + if (team.teamNumber != null) " | ${team.teamNumber}" else "" }
+                column("Teammitglieder"){ team.participants.joinToString(", ") { "${it.firstName} ${it.lastName} [${it.namedParticipantName}] (${it.externalClubName?:team.clubName})" }}
 
             }
             out.toByteArray()

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/Conversions.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/control/Conversions.kt
@@ -278,7 +278,11 @@ fun CompetitionSetupRoundWithMatchesRecord.toCompetitionSetupRoundWithMatches() 
 )
 
 
-fun CompetitionMatchTeamWithRegistration.toCompetitionTeamPlaceDto(place: Int, categoryPlace: Int?) = KIO.ok(
+fun CompetitionMatchTeamWithRegistration.toCompetitionTeamPlaceDto(
+    place: Int,
+    categoryPlace: Int?,
+    matchName: String? = null,
+) = KIO.ok(
     CompetitionTeamPlaceDto(
         ratingCategory = ratingCategory,
         categoryPlace = categoryPlace,
@@ -289,6 +293,7 @@ fun CompetitionMatchTeamWithRegistration.toCompetitionTeamPlaceDto(place: Int, c
         clubName = clubName,
         namedParticipants = participants.toNamedParticipantsDto(),
         place = place,
+        matchName = matchName,
         deregistered = deregistered,
         deregistrationReason = deregistrationReason,
         excluded = deregistered || out || failed,

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/CompetitionTeamPlaceDto.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/CompetitionTeamPlaceDto.kt
@@ -21,6 +21,11 @@ data class CompetitionTeamPlaceDto(
      * Mannschaften.
      */
     val categoryPlace: Int?,
+    /**
+     * Die Partie, in der der Platz gefahren wurde — nur gesetzt, wenn die Runde je Partie
+     * gewertet wird und mehrere Partien je einen Ersten haben.
+     */
+    val matchName: String?,
     val deregistered: Boolean,
     val deregistrationReason: String?,
     val excluded: Boolean,

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TeamPlacement.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TeamPlacement.kt
@@ -1,0 +1,23 @@
+package de.lambda9.ready2race.backend.app.competitionExecution.entity
+
+/**
+ * Ein Boot mit dem Platz, den die Rundenlogik ihm gegeben hat.
+ *
+ * [matchName] und [matchWeighting] stehen nur, wenn die Runde je Partie gewertet wird
+ * (`CompetitionSetupPlacesOption.PER_MATCH`): Dann ist [place] der Platz INNERHALB dieser Partie -
+ * Finale A, B und C haben jeweils einen Ersten - und die Partie gehört zur Aussage dazu. Bei allen
+ * anderen Wertungen gilt der Platz für die ganze Runde und beide Felder bleiben leer.
+ */
+data class TeamPlacement(
+    val team: CompetitionMatchTeamWithRegistration,
+    val place: Int,
+    val matchName: String? = null,
+    val matchWeighting: Int? = null,
+) {
+    /**
+     * Der Schlüssel, nach dem Platzierungen untereinander geordnet werden: erst die Partie in
+     * Setup-Reihenfolge, dann der Platz. Ohne Wertung je Partie ist der Partie-Anteil für alle
+     * gleich, es entscheidet also allein der Platz.
+     */
+    fun rankKey(): Pair<Int, Int> = (matchWeighting ?: 0) to place
+}

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionSetup/entity/CompetitionSetupPlacesOption.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionSetup/entity/CompetitionSetupPlacesOption.kt
@@ -1,5 +1,5 @@
 package de.lambda9.ready2race.backend.app.competitionSetup.entity
 
 enum class CompetitionSetupPlacesOption {
-    EQUAL, ASCENDING, CUSTOM;
+    EQUAL, ASCENDING, CUSTOM, PER_MATCH;
 }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/results/boundary/ResultsService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/results/boundary/ResultsService.kt
@@ -355,6 +355,7 @@ object ResultsService {
 
                                 EventResultData.TeamResultData(
                                     place = entry.item.categoryPlace,
+                                    matchName = entry.item.matchName,
                                     clubName = team.clubName,
                                     teamName = team.registrationName,
                                     participatingClubName = actualClubName,
@@ -576,6 +577,12 @@ object ResultsService {
                                         // Die Mannschaft bleibt in der Liste, damit niemand sie
                                         // für vergessen hält.
                                         team.place?.toString() ?: "-"
+                                    }
+                                    team.matchName?.let {
+                                        text(
+                                            fontSize = 9f,
+                                            centered = true,
+                                        ) { it }
                                     }
                                 }
 

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/results/entity/CompetitionResultData.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/results/entity/CompetitionResultData.kt
@@ -36,6 +36,8 @@ data class EventResultData(
          * ohne Platz.
          */
         val place: Int?,
+        /** Die Partie, in der der Platz gefahren wurde - nur bei Wertung je Partie gesetzt. */
+        val matchName: String?,
         val clubName: String,
         val teamName: String?,
         val participatingClubName: String?,

--- a/backend/src/main/resources/openapi/documentation.yaml
+++ b/backend/src/main/resources/openapi/documentation.yaml
@@ -12007,6 +12007,7 @@ components:
             - EQUAL
             - ASCENDING
             - CUSTOM
+            - PER_MATCH
         places:
           type: array
           items:
@@ -14508,6 +14509,12 @@ components:
           type: integer
           nullable: true
           description: "the place within the rating category, counted from 1; null for excluded teams"
+        matchName:
+          type: string
+          nullable: true
+          description: >-
+            Name of the match the place was scored in. Only set when the round scores places
+            separately per match (each match has its own first place).
         deregistered:
           type: boolean
         deregistrationReason:

--- a/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/PerMatchPlacesTest.kt
+++ b/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/PerMatchPlacesTest.kt
@@ -1,0 +1,115 @@
+package de.lambda9.ready2race.backend.app.competitionExecution
+
+import de.lambda9.ready2race.backend.app.competitionExecution.boundary.CompetitionExecutionService
+import de.lambda9.ready2race.backend.app.competitionExecution.entity.CompetitionMatchTeamWithRegistration
+import de.lambda9.ready2race.backend.app.competitionExecution.entity.TeamPlacement
+import de.lambda9.ready2race.backend.app.competitionSetup.entity.CompetitionSetupPlacesOption
+import de.lambda9.ready2race.backend.app.ratingcategory.entity.RatingCategoryRef
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Wertung je Partie: Finale A, B und C haben jeweils einen Ersten.
+ *
+ * Der Platz ist damit der Platz IN DER PARTIE und für sich genommen mehrdeutig - zwei Boote
+ * tragen eine „1". Für Reihenfolge und Kategoriewertung zählt deshalb die Partie zuerst
+ * (Setup-Reihenfolge über `weighting`) und der Platz danach; ohne das stünden in der
+ * Ergebnisliste abwechselnd Erste und Zweite verschiedener Partien untereinander.
+ */
+class PerMatchPlacesTest {
+
+    private fun team(startNumber: Int, category: RatingCategoryRef? = null) =
+        CompetitionMatchTeamWithRegistration(
+            id = UUID.randomUUID(),
+            competitionMatch = UUID.randomUUID(),
+            startNumber = startNumber,
+            place = null,
+            timeString = null,
+            placesCalculated = true,
+            competitionRegistration = UUID.randomUUID(),
+            clubId = UUID.randomUUID(),
+            clubName = "Verein $startNumber",
+            registrationName = null,
+            teamNumber = null,
+            participants = emptyList(),
+            deregistered = false,
+            deregistrationReason = null,
+            out = false,
+            failed = false,
+            failedReason = null,
+            penaltySeconds = null,
+            penaltyNote = null,
+            ratingCategory = category,
+            mixedTeamTerm = null,
+        )
+
+    /** Finale A (weighting 1) und Finale B (weighting 2) mit je zwei Booten. */
+    private fun zweiFinals() = listOf(
+        TeamPlacement(team(1), place = 1, matchName = "Finale A", matchWeighting = 1),
+        TeamPlacement(team(2), place = 2, matchName = "Finale A", matchWeighting = 1),
+        TeamPlacement(team(3), place = 1, matchName = "Finale B", matchWeighting = 2),
+        TeamPlacement(team(4), place = 2, matchName = "Finale B", matchWeighting = 2),
+    )
+
+    @Test
+    fun wertungJePartieBrauchtKeineSeedingListe() {
+        assertNull(
+            CompetitionExecutionService.getPlacesSeedingList(
+                placesOption = CompetitionSetupPlacesOption.PER_MATCH.name,
+                currentRoundTeams = listOf(3, 3),
+                seedsForNextRound = 0,
+                teamsInThisRound = 6,
+            )
+        )
+    }
+
+    @Test
+    fun partienStehenNacheinanderUndNichtVerschraenkt() {
+        val entries = CompetitionExecutionService.placesByRatingCategory(zweiFinals())
+            .flatMap { it.entries }
+
+        assertEquals(
+            listOf("Finale A" to 1, "Finale A" to 2, "Finale B" to 1, "Finale B" to 2),
+            entries.map { it.item.matchName to it.item.place },
+        )
+        assertEquals(listOf(1, 2, 3, 4), entries.map { it.categoryPlace })
+    }
+
+    @Test
+    fun jedeWertungskategorieZaehltFuerSichAbEins() {
+        val leicht = RatingCategoryRef(UUID.randomUUID(), "Leichtgewicht", 1)
+        val offen = RatingCategoryRef(UUID.randomUUID(), "Offen", 2)
+
+        val sections = CompetitionExecutionService.placesByRatingCategory(
+            listOf(
+                TeamPlacement(team(1, leicht), place = 1, matchName = "Finale A", matchWeighting = 1),
+                TeamPlacement(team(2, offen), place = 2, matchName = "Finale A", matchWeighting = 1),
+                TeamPlacement(team(3, leicht), place = 1, matchName = "Finale B", matchWeighting = 2),
+                TeamPlacement(team(4, offen), place = 2, matchName = "Finale B", matchWeighting = 2),
+            )
+        )
+
+        assertEquals(listOf("Leichtgewicht", "Offen"), sections.map { it.category?.name })
+        sections.forEach { section ->
+            assertEquals(listOf(1, 2), section.entries.map { it.categoryPlace })
+        }
+    }
+
+    @Test
+    fun ohneWertungJePartieEntscheidetWeiterhinAlleinDerPlatz() {
+        // Gleichstand aus EQUAL: gleicher Platz, gleicher Kategorieplatz - unverändert zur
+        // bisherigen Zählung, obwohl die Reihenfolge jetzt über einen Rang läuft.
+        val entries = CompetitionExecutionService.placesByRatingCategory(
+            listOf(
+                TeamPlacement(team(1), place = 3),
+                TeamPlacement(team(2), place = 3),
+                TeamPlacement(team(3), place = 1),
+            )
+        ).flatMap { it.entries }
+
+        assertEquals(listOf(1, 2, 2), entries.map { it.categoryPlace })
+        assertEquals(listOf(1, 3, 3), entries.map { it.item.place })
+    }
+}

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1215,7 +1215,7 @@ export type CompetitionSetupRoundDto = {
     groups?: Array<CompetitionSetupGroupDto>
     statisticEvaluations?: Array<CompetitionSetupGroupStatisticEvaluationDto>
     useDefaultSeeding: boolean
-    placesOption: 'EQUAL' | 'ASCENDING' | 'CUSTOM'
+    placesOption: 'EQUAL' | 'ASCENDING' | 'CUSTOM' | 'PER_MATCH'
     places?: Array<CompetitionSetupPlaceDto>
     /**
      * Marks a preliminary / qualification round. The number of teams qualifying out of the qualification round(s) defines the fixed bracket size N used to resolve the match namings.
@@ -1224,7 +1224,7 @@ export type CompetitionSetupRoundDto = {
     matchNamings?: Array<CompetitionSetupMatchNamingDto>
 }
 
-export type placesOption = 'EQUAL' | 'ASCENDING' | 'CUSTOM'
+export type placesOption = 'EQUAL' | 'ASCENDING' | 'CUSTOM' | 'PER_MATCH'
 
 export type CompetitionSetupTemplateDto = {
     id: string
@@ -1287,6 +1287,10 @@ export type CompetitionTeamPlaceDto = {
      * the place within the rating category, counted from 1; null for excluded teams
      */
     categoryPlace?: number | null
+    /**
+     * Name of the match the place was scored in. Only set when the round scores places separately per match (each match has its own first place).
+     */
+    matchName?: string | null
     deregistered: boolean
     deregistrationReason?: string
     excluded: boolean

--- a/frontend/src/components/event/competition/excecution/CompetitionPlaces.tsx
+++ b/frontend/src/components/event/competition/excecution/CompetitionPlaces.tsx
@@ -163,10 +163,21 @@ const CompetitionPlaces = () => {
                                             }}>
                                             {/* Der Platz innerhalb der Wertungskategorie; team.place
                                         bleibt der wettkampfweite und traegt weiterhin die Urkunde. */}
-                                            <Typography
-                                                variant={team.categoryPlace ? 'h5' : 'body1'}>
-                                                {team.categoryPlace ?? '-'}
-                                            </Typography>
+                                            <Box>
+                                                <Typography
+                                                    variant={team.categoryPlace ? 'h5' : 'body1'}>
+                                                    {team.categoryPlace ?? '-'}
+                                                </Typography>
+                                                {/* Bei Wertung je Partie gehoert die Partie zum Platz:
+                                        ohne sie stuenden mehrere Erste ohne Herkunft nebeneinander. */}
+                                                {team.matchName && (
+                                                    <Typography
+                                                        color={'textSecondary'}
+                                                        variant={'body2'}>
+                                                        {team.matchName}
+                                                    </Typography>
+                                                )}
+                                            </Box>
                                             <Box>
                                                 <Typography textAlign={'right'}>
                                                     {team.actualClubName ?? team.clubName}

--- a/frontend/src/components/event/competition/setup/CompetitionSetupMatch.tsx
+++ b/frontend/src/components/event/competition/setup/CompetitionSetupMatch.tsx
@@ -110,7 +110,13 @@ const CompetitionSetupMatch = ({formContext, roundIndex, fieldInfo, ...props}: P
                         props.participantFunctions,
                         props.teamCounts,
                         () => {
-                            formContext.setValue(`rounds.${roundIndex}.placesOption`, 'EQUAL')
+                            // Only CUSTOM requires defined team counts - other options stay selected
+                            if (
+                                formContext.getValues(`rounds.${roundIndex}.placesOption`) ===
+                                'CUSTOM'
+                            ) {
+                                formContext.setValue(`rounds.${roundIndex}.placesOption`, 'EQUAL')
+                            }
                         },
                     )
                 }}

--- a/frontend/src/components/event/competition/setup/CompetitionSetupRound.tsx
+++ b/frontend/src/components/event/competition/setup/CompetitionSetupRound.tsx
@@ -520,6 +520,11 @@ const CompetitionSetupRound = ({round, formContext, removeRound, teamCounts, ...
                                                                 'event.competition.setup.place.placesOption.ascending',
                                                             )}
                                                         </MenuItem>
+                                                        <MenuItem value={'PER_MATCH'}>
+                                                            {t(
+                                                                'event.competition.setup.place.placesOption.perMatch',
+                                                            )}
+                                                        </MenuItem>
                                                         {!roundHasUndefinedTeams && (
                                                             <MenuItem value={'CUSTOM'}>
                                                                 {t(

--- a/frontend/src/components/event/competition/setup/common.ts
+++ b/frontend/src/components/event/competition/setup/common.ts
@@ -30,7 +30,7 @@ export type FormSetupRound = {
     groups: Array<FormSetupGroup>
     statisticEvaluations?: Array<CompetitionSetupGroupStatisticEvaluationDto>
     useDefaultSeeding: boolean
-    placesOption: 'EQUAL' | 'ASCENDING' | 'CUSTOM'
+    placesOption: 'EQUAL' | 'ASCENDING' | 'CUSTOM' | 'PER_MATCH'
     places: Array<{
         roundOutcome: number
         place: number

--- a/frontend/src/i18n/da/translations.json
+++ b/frontend/src/i18n/da/translations.json
@@ -993,7 +993,8 @@
           "placesOption": {
             "equal": "Ligestillet (placering = {{place}})",
             "ascending": "Stigende (placering = seedning)",
-            "custom": "Brugerdefineret"
+            "custom": "Brugerdefineret",
+            "perMatch": "Pr. kamp (placering = placering i kampen)"
           }
         },
         "tournamentTree": {

--- a/frontend/src/i18n/de/translations.json
+++ b/frontend/src/i18n/de/translations.json
@@ -993,7 +993,8 @@
           "placesOption": {
             "equal": "Gleichgestellt (Platz = {{place}})",
             "ascending": "Aufsteigend (Platz = Setzung)",
-            "custom": "Benutzerdefiniert"
+            "custom": "Benutzerdefiniert",
+            "perMatch": "Pro Partie (Platz = Platz in der Partie)"
           }
         },
         "tournamentTree": {

--- a/frontend/src/i18n/en/translations.json
+++ b/frontend/src/i18n/en/translations.json
@@ -993,7 +993,8 @@
           "placesOption": {
             "equal": "Equal (Place = {{place}})",
             "ascending": "Ascending (Place = Seeding)",
-            "custom": "Custom"
+            "custom": "Custom",
+            "perMatch": "Per match (Place = Place within the match)"
           }
         },
         "tournamentTree": {


### PR DESCRIPTION
Eine Runde ließ sich bisher nur als Ganzes werten — aufsteigend über alle Partien (1 bis N), gleichgestellt oder über eine Platztabelle. Für ein Feld, das in Finale A, B und C aufgeteilt gefahren wird, trifft keine davon zu: Dort gewinnt jede Partie für sich.

Das Vorgehen ist mit Steffen aus Greifswald abgesprochen.

## Was drin ist

- Neue Wertungsoption `PER_MATCH` in der Runden-Einrichtung. Keine Migration nötig, `places_option` ist `text` ohne Constraint.
- Der Platz ist bei dieser Wertung der Platz **in der Partie**. Die Partie gehört damit zur Aussage dazu und steht neben dem Platz: in der Platzierungsansicht, im Ergebnis-PDF und als eigene Spalte in der CSV (letztere nur, wenn es je Partie gewertete Plätze gibt).
- Reihenfolge und Zählung je Wertungskategorie laufen über einen Rang aus Partie (Setup-Reihenfolge) und Platz: Der Erste aus Finale B steht hinter dem Letzten aus Finale A. Ohne diese Wertung entscheidet weiterhin allein der Platz, Gleichstände bleiben Gleichstände — belegt durch einen Test.
- `computeCompetitionPlaces` liefert statt `Pair<Team, Int>` ein `TeamPlacement`. Die übrigen Konsumenten (Urkunden, Siegerehrungsbogen) destrukturieren weiter wie bisher.
- Eine Partie auf „unbegrenzte Boote" zu stellen setzt die Wertung nur noch zurück, wenn sie `CUSTOM` war — nur die braucht feste Bootszahlen.

## Was ihr wissen solltet

Urkunden und Siegerehrungsbogen lesen denselben Platz. Der Sieger aus Finale B bekommt also eine Urkunde für Platz 1 — bei dieser Wertung so gemeint, aber dort ohne den Zusatz der Partie. Falls die Partie auf Urkunde oder Bogen mit soll, ist das ein eigener Schritt.

## Geprüft

`./mvnw test` (1112 grün, inkl. vier neuer Fälle in `PerMatchPlacesTest`), `npm run build` und `npm test` (1232 grün) gegen den aktuellen `main`.
