### PR TITLE
Nennung der Zeitnahme neben die Uhrzeit statt in die Fußzeile

### DIFF
--- a/frontend/src/components/results/ResultsMatchDialog.tsx
+++ b/frontend/src/components/results/ResultsMatchDialog.tsx
@@ -96,12 +96,31 @@ const ResultsMatchDialog = <M extends ResultsMatchInfo>({
                     </DialogTitle>
                     <DialogContent>
                         <Stack spacing={2}>
-                            {match.startTime && (
-                                <Stack direction={'row'} spacing={1}>
-                                    <ScheduleOutlinedIcon color={'primary'} />
-                                    <Typography>
-                                        {format(new Date(match.startTime), t('format.datetime'))}
-                                    </Typography>
+                            {/* Uhrzeit und Nennung der Zeitnahme in einer Zeile, gleich zu Anfang:
+                                Wer die Zeiten gemessen hat, gehört zur Zeitangabe und nicht in eine
+                                Fußzeile, die erst nach dem Durchblättern aller Boote auftaucht.
+                                Auf schmalen Anzeigen bricht die Nennung in die zweite Zeile um. */}
+                            {(match.startTime || 'timingProviderName' in match) && (
+                                <Stack
+                                    direction={'row'}
+                                    spacing={2}
+                                    alignItems={'center'}
+                                    flexWrap={'wrap'}
+                                    useFlexGap>
+                                    {match.startTime && (
+                                        <Stack direction={'row'} spacing={1} alignItems={'center'}>
+                                            <ScheduleOutlinedIcon color={'primary'} />
+                                            <Typography>
+                                                {format(
+                                                    new Date(match.startTime),
+                                                    t('format.datetime'),
+                                                )}
+                                            </Typography>
+                                        </Stack>
+                                    )}
+                                    {'timingProviderName' in match && (
+                                        <TimingProviderAttribution matches={[match]} inline />
+                                    )}
                                 </Stack>
                             )}
                             {sections.map(section => (
@@ -277,9 +296,6 @@ const ResultsMatchDialog = <M extends ResultsMatchInfo>({
                                     ))}
                                 </Stack>
                             ))}
-                            {'timingProviderName' in match && (
-                                <TimingProviderAttribution matches={[match]} />
-                            )}
                         </Stack>
                     </DialogContent>
                     <DialogActions>

--- a/frontend/src/components/results/TimingProviderAttribution.tsx
+++ b/frontend/src/components/results/TimingProviderAttribution.tsx
@@ -9,11 +9,17 @@ type TimingProviderSource = {
 
 type Props = {
     matches: TimingProviderSource[]
+    /**
+     * Inline steht die Nennung in einer fremden Zeile - im Lauf-Dialog direkt hinter der Uhrzeit.
+     * Sie trägt dort dieselbe Schrift und dieselbe Symbolfarbe wie die Zeitangabe daneben, statt
+     * als kleingedruckte Fußzeile unter der ganzen Liste zu stehen.
+     */
+    inline?: boolean
 }
 
 // Attribution of the external timing provider (e.g. RaceClocker) whose terms require a visible
 // reference/link wherever their timing data is published.
-const TimingProviderAttribution = ({matches}: Props) => {
+const TimingProviderAttribution = ({matches, inline = false}: Props) => {
     const {t} = useTranslation()
 
     const providers = [
@@ -31,12 +37,17 @@ const TimingProviderAttribution = ({matches}: Props) => {
     return (
         <Stack
             direction={'row'}
-            spacing={0.5}
-            justifyContent={'center'}
+            spacing={inline ? 1 : 0.5}
+            justifyContent={inline ? undefined : 'center'}
             alignItems={'center'}
-            sx={{py: 1}}>
-            <TimerOutlinedIcon color={'action'} fontSize={'inherit'} />
-            <Typography variant={'body2'} color={'textSecondary'}>
+            sx={inline ? undefined : {py: 1}}>
+            <TimerOutlinedIcon
+                color={inline ? 'primary' : 'action'}
+                fontSize={inline ? undefined : 'inherit'}
+            />
+            <Typography
+                variant={inline ? undefined : 'body2'}
+                color={inline ? undefined : 'textSecondary'}>
                 {t('results.timing.attribution')}{' '}
                 {providers.map(([name, url], index) => (
                     <span key={name}>


### PR DESCRIPTION
Nachtrag zu #107. Die Nennung steht live, aber am unauffälligsten Platz des Lauf-Dialogs: klein und grau unter der letzten Bootskarte, sichtbar erst, wer den ganzen Lauf durchgeblättert hat.

Sie steht jetzt **gleich zu Anfang in derselben Zeile wie die Uhrzeit** — dort, wo die Aussage hingehört: diese Zeiten wurden damit gemessen. Gleiche Schrift und gleiche Symbolfarbe wie die Zeitangabe daneben, der Anbietername bleibt der Link.

- Auf schmalen Anzeigen bricht die Nennung unter die Uhrzeit um. Der Stack läuft dafür mit `useFlexGap` — mit den sonst üblichen Randabständen verrutschen umgebrochene Zeilen.
- Ein Lauf ohne Startzeit zeigt die Nennung allein, ein Lauf ohne Nennung nur die Uhrzeit.
- Die Fußzeile unter der **Ergebnisliste** bleibt unverändert: dort gilt die Nennung allen Läufen der Liste gemeinsam, nicht einem einzelnen.

Reines Frontend, keine Migration, keine API-Änderung.

## Geprüft

`npm run build` und `npm test` (1232 grün) gegen den aktuellen `main`.