### PR TITLE
Wertung je Partie in allen Anzeigen: jede Partie zählt für sich

### DIFF
--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/boundary/AwardCeremonyLogic.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/boundary/AwardCeremonyLogic.kt
@@ -44,10 +44,14 @@ object AwardCeremonyLogic {
         .mapNotNull { entry -> entry.categoryPlace?.let { it to entry.item } }
         .filter { (place, _) -> maxRank == null || place <= maxRank }
         // groupBy hält die Reihenfolge der zuerst gesehenen Schlüssel, und die Einträge kommen
-        // bereits nach Platz und Startnummer sortiert an - die Blockfolge bleibt damit die des Blatts.
-        .groupBy { (place, _) -> place }
-        .flatMap { (place, tied) ->
-            tied.mapIndexed { position, (_, candidate) ->
+        // bereits nach Partie, Platz und Startnummer sortiert an - die Blockfolge bleibt damit die
+        // des Blatts. Die Partie steht mit im Schlüssel: bei Wertung je Partie zählt jede ihre
+        // Ränge für sich, der Schnitt bei [maxRank] gilt also je Partie, und die Ersten zweier
+        // Finals sind KEIN geteilter Rang - welche Partie ein Block meint, sagt die Rennzeile
+        // seiner Boote. Ohne diese Wertung ist die Partie überall null und nichts ändert sich.
+        .groupBy { (place, candidate) -> candidate.placementMatchName to place }
+        .flatMap { (_, tied) ->
+            tied.mapIndexed { position, (place, candidate) ->
                 AwardCeremonyRank(
                     rank = place,
                     shared = tied.size > 1,

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/boundary/AwardCeremonyService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/boundary/AwardCeremonyService.kt
@@ -172,6 +172,7 @@ object AwardCeremonyService {
                     category = { if (options.byRatingCategory) it.ratingCategory else null },
                     place = { it.competitionPlace },
                     tieBreak = { it.startNumber },
+                    subgroup = { it.placementMatchWeighting },
                 )
                 sections.map { section ->
                     AwardCeremonyLogic.sheet(
@@ -301,11 +302,13 @@ object AwardCeremonyService {
             KIO.ok(
                 places
                     .filterNot { (team, _) -> team.deregistered || team.out || team.failed }
-                    .map { (team, place) ->
+                    .map { (team, place, partieName, partieWeighting) ->
                         val (roundName, matchName, matchTime) = raceOf(rounds, team.competitionRegistration)
 
                         AwardCeremonyCandidate(
                             competitionPlace = place,
+                            placementMatchName = partieName,
+                            placementMatchWeighting = partieWeighting,
                             startNumber = team.startNumber,
                             ratingCategory = team.ratingCategory,
                             registeringClubName = team.clubName,
@@ -346,6 +349,7 @@ object AwardCeremonyService {
                 category = { it.ratingCategory },
                 place = { it.competitionPlace },
                 tieBreak = { it.startNumber },
+                subgroup = { it.placementMatchWeighting },
             )
 
             KIO.ok(

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/entity/AwardCeremony.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/entity/AwardCeremony.kt
@@ -30,6 +30,14 @@ data class AwardCeremonyCandidate(
     val roundName: String?,
     val matchName: String?,
     val matchTime: LocalDateTime?,
+    /**
+     * Die Partie, in der der Platz VERGEBEN wurde - nur bei Wertung je Partie gesetzt (siehe
+     * `TeamPlacement`). Nicht dasselbe wie [matchName]: der beschreibt das zuletzt gefahrene
+     * Rennen fürs Blatt, diese beiden hier steuern Rechnung und Blockbildung - jede Partie zählt
+     * ihre Ränge für sich, und nur Boote derselben Partie können sich einen teilen.
+     */
+    val placementMatchName: String? = null,
+    val placementMatchWeighting: Int? = null,
     val participants: List<AwardCeremonyCandidateParticipant>,
 )
 

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
@@ -2260,6 +2260,8 @@ object CompetitionExecutionService {
         val categoryPlace: Int?,
         /** Die Partie, in der der Platz gefahren wurde - nur bei Wertung je Partie gesetzt. */
         val matchName: String?,
+        /** Die Setup-Reihenfolge der Partie - ordnet die Partien untereinander an. */
+        val matchWeighting: Int?,
     )
 
     /**
@@ -2267,43 +2269,32 @@ object CompetitionExecutionService {
      * jedem Abschnitt neu ab 1. [computeCompetitionPlaces] selbst bleibt unberührt und liefert
      * weiter die wettkampfweite Platzierung — daran hängen die Urkunden.
      *
+     * Wird je Partie gewertet, zählt jede Partie für sich: Finale A, B und C haben in jeder
+     * Kategorie je einen Ersten, und der Erste aus Finale B steht hinter dem Letzten aus
+     * Finale A. Beides — Anordnung und Neuzählung — erledigt `RatingCategoryRanking` über die
+     * Partie-Dimension; die Anzeige stellt den Partienamen daneben.
+     *
      * Abgemeldete, ausgeschiedene und disqualifizierte Boote gelten hier als ungewertet: sie haben
      * zwar einen rechnerischen Platz, aber keinen, der in einer Ergebnisliste etwas zu suchen hat.
      * Sie behalten ihren Abschnitt und stehen dort am Ende.
      */
     fun placesByRatingCategory(
         places: List<TeamPlacement>,
-    ): List<RankedCategory<PlaceInCategory>> {
-
-        // Der Rang, nach dem geordnet und im Abschnitt durchgezählt wird. Ohne Wertung je Partie
-        // ist das die Reihenfolge der Plätze selbst. Wird je Partie gewertet, sind die Plätze nur
-        // innerhalb ihrer Partie vergleichbar - der Erste aus Finale B steht hinter dem Letzten
-        // aus Finale A, sonst stünden in der Ergebnisliste abwechselnd Erste und Zweite
-        // verschiedener Partien. Gleiche Schlüssel behalten denselben Rang, Gleichstände (etwa aus
-        // EQUAL) bleiben also Gleichstände.
-        val rankByKey = places
-            .map { it.rankKey() }
-            .distinct()
-            .sortedWith(compareBy({ it.first }, { it.second }))
-            .withIndex()
-            .associate { (index, key) -> key to index + 1 }
-
-        val rankByTeam = places.associate { it.team.competitionRegistration to rankByKey.getValue(it.rankKey()) }
-
-        return RatingCategoryRanking.groupAndRank(
-            items = places.map { PlaceInCategory(it.team, it.place, null, it.matchName) },
+    ): List<RankedCategory<PlaceInCategory>> =
+        RatingCategoryRanking.groupAndRank(
+            items = places.map { PlaceInCategory(it.team, it.place, null, it.matchName, it.matchWeighting) },
             category = { it.team.ratingCategory },
             place = {
                 if (it.team.deregistered || it.team.out || it.team.failed) null
-                else rankByTeam[it.team.competitionRegistration]
+                else it.place
             },
             tieBreak = { it.team.startNumber },
+            subgroup = { it.matchWeighting },
         ).map { section ->
             section.copy(
                 entries = section.entries.map { it.copy(item = it.item.copy(categoryPlace = it.categoryPlace)) }
             )
         }
-    }
 
     fun getCompetitionPlaces(
         eventId: UUID,
@@ -3227,10 +3218,7 @@ object CompetitionExecutionService {
         val bytes = ByteArrayOutputStream().use { out ->
             CSV.write(
                 out,
-                // Bei Wertung je Partie kommen die Partien in Setup-Reihenfolge, innerhalb der
-                // Partie nach Platz - sonst stünden abwechselnd Erste und Zweite verschiedener
-                // Partien untereinander. Ohne diese Wertung entscheidet allein der Platz.
-                teamsData.sortedWith(compareBy({ it.matchWeighting ?: 0 }, { it.place }))
+                teamsData.sortedWith(TeamPlacement.ordering)
             ) {
 
                 column("Veranstaltung") { competitionData.eventName }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TeamPlacement.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TeamPlacement.kt
@@ -14,10 +14,15 @@ data class TeamPlacement(
     val matchName: String? = null,
     val matchWeighting: Int? = null,
 ) {
-    /**
-     * Der Schlüssel, nach dem Platzierungen untereinander geordnet werden: erst die Partie in
-     * Setup-Reihenfolge, dann der Platz. Ohne Wertung je Partie ist der Partie-Anteil für alle
-     * gleich, es entscheidet also allein der Platz.
-     */
-    fun rankKey(): Pair<Int, Int> = (matchWeighting ?: 0) to place
+    companion object {
+        /**
+         * Die Reihenfolge der Platzierungen untereinander: Partien in Setup-Reihenfolge, innerhalb
+         * der Partie nach Platz. Platzierungen ohne Partie stehen hinter allen Partien - das sind
+         * in einem Wettkampf mit Wertung je Partie die Boote früherer Runden, deren Plätze das
+         * Gesamtfeld zählen und numerisch hinter den Partie-internen liegen. Ohne Wertung je
+         * Partie sind alle Partie-Anteile gleich, es entscheidet also allein der Platz.
+         */
+        val ordering: Comparator<TeamPlacement> =
+            compareBy({ it.matchWeighting ?: Int.MAX_VALUE }, { it.place })
+    }
 }

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/ratingcategory/boundary/RatingCategoryRanking.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/ratingcategory/boundary/RatingCategoryRanking.kt
@@ -35,19 +35,28 @@ object RatingCategoryRanking {
      * ausgeschieden, disqualifiziert oder schlicht noch nicht gewertet.
      * @param tieBreak Entscheidet die Reihenfolge zwischen Booten mit demselben Platz und
      * zwischen den ungewerteten; in der Praxis die Startnummer.
+     * @param subgroup Die Partie des Bootes in Setup-Reihenfolge, wenn die Runde je Partie
+     * gewertet wird (`CompetitionSetupPlacesOption.PER_MATCH`) — dann ist [place] nur innerhalb
+     * derselben Partie vergleichbar. Die Partien stehen nacheinander, in jeder beginnt die
+     * Zählung neu ab 1, und nur Boote derselben Partie können sich einen Platz teilen. `null`
+     * heißt „ohne Partie" und steht hinter allen Partien: solche Plätze zählen das Gesamtfeld
+     * einer Runde — sie zählen deshalb an der Gesamtposition weiter, statt neu zu beginnen (nach
+     * Finale A mit 1–2 und Finale B mit 1–2 ist ein Vorrunden-Ausgeschiedener der 5.). Ohne
+     * Wertung je Partie sind alle Werte `null`, und alles bleibt beim Alten.
      */
     fun <T> groupAndRank(
         items: List<T>,
         category: (T) -> RatingCategoryRef?,
         place: (T) -> Int?,
         tieBreak: (T) -> Int,
+        subgroup: (T) -> Int? = { null },
     ): List<RankedCategory<T>> = items
         .groupBy { category(it)?.id }
         .map { (_, boats) ->
             val ref = category(boats.first())
             RankedCategory(
                 category = ref,
-                entries = rankWithinCategory(boats, place, tieBreak),
+                entries = rankWithinCategory(boats, place, tieBreak, subgroup),
             )
         }
         // Ein Abschnitt ohne Kategorie sortiert sich nicht gegen die anderen, er hängt hinten an.
@@ -72,19 +81,35 @@ object RatingCategoryRanking {
         boats: List<T>,
         place: (T) -> Int?,
         tieBreak: (T) -> Int,
+        subgroup: (T) -> Int?,
     ): List<RankedEntry<T>> {
         val (ranked, unranked) = boats.partition { place(it) != null }
 
-        val sorted = ranked.sortedWith(compareBy({ place(it)!! }, { tieBreak(it) }))
+        val sorted = ranked.sortedWith(
+            compareBy({ subgroup(it) ?: Int.MAX_VALUE }, { place(it)!! }, { tieBreak(it) })
+        )
 
+        var currentSubgroup: Int? = null
+        var subgroupStart = 0
         var lastPlace: Int? = null
         var lastCategoryPlace = 0
 
         val rankedEntries = sorted.mapIndexed { index, boat ->
+            // Partiewechsel: die Zählung beginnt neu, und der letzte Platz der vorigen Partie
+            // stiftet keinen Gleichstand über die Partiegrenze hinweg. Boote ohne Partie zählen
+            // dagegen an der Gesamtposition weiter (subgroupStart bleibt 0) - ihr Platz misst
+            // das Gesamtfeld, nicht eine Partie.
+            if (index == 0 || subgroup(boat) != currentSubgroup) {
+                currentSubgroup = subgroup(boat)
+                subgroupStart = if (subgroup(boat) != null) index else 0
+                lastPlace = null
+                lastCategoryPlace = 0
+            }
+
             val categoryPlace = if (place(boat) == lastPlace) {
                 lastCategoryPlace
             } else {
-                index + 1
+                index - subgroupStart + 1
             }
             lastPlace = place(boat)
             lastCategoryPlace = categoryPlace

--- a/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/AwardCeremonyLogicTest.kt
+++ b/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/awardCeremony/AwardCeremonyLogicTest.kt
@@ -62,6 +62,8 @@ class AwardCeremonyLogicTest {
         penaltyNote: String? = null,
         roundName: String? = "Finale",
         matchName: String? = "Finale A",
+        placementMatchName: String? = null,
+        placementMatchWeighting: Int? = null,
         participants: List<AwardCeremonyCandidateParticipant> = listOf(rower()),
     ) = AwardCeremonyCandidate(
         competitionPlace = place,
@@ -75,8 +77,40 @@ class AwardCeremonyLogicTest {
         roundName = roundName,
         matchName = matchName,
         matchTime = null,
+        placementMatchName = placementMatchName,
+        placementMatchWeighting = placementMatchWeighting,
         participants = participants,
     )
+
+    /**
+     * Wertung je Partie (`CompetitionSetupPlacesOption.PER_MATCH`): Finale A und B haben je einen
+     * Ersten. Auf dem Bogen sind das getrennte Blöcke in Partie-Reihenfolge - kein geteilter
+     * Rang -, und der Podiumsschnitt gilt je Partie: beide Sieger werden geehrt.
+     */
+    @Test
+    fun wertungJePartieEhrtJedePartieFuerSich() {
+        val entries = RatingCategoryRanking.groupAndRank(
+            items = listOf(
+                candidate(1, startNumber = 1, matchName = "Finale A", placementMatchName = "Finale A", placementMatchWeighting = 1),
+                candidate(2, startNumber = 2, matchName = "Finale A", placementMatchName = "Finale A", placementMatchWeighting = 1),
+                candidate(1, startNumber = 3, matchName = "Finale B", placementMatchName = "Finale B", placementMatchWeighting = 2),
+                candidate(2, startNumber = 4, matchName = "Finale B", placementMatchName = "Finale B", placementMatchWeighting = 2),
+            ),
+            category = { it.ratingCategory },
+            place = { it.competitionPlace },
+            tieBreak = { it.startNumber },
+            subgroup = { it.placementMatchWeighting },
+        ).single().entries
+
+        val ranks = AwardCeremonyLogic.ranks(entries)
+
+        assertEquals(listOf(1, 2, 1, 2), ranks.map { it.rank })
+        assertEquals(listOf(false, false, false, false), ranks.map { it.shared })
+        assertEquals(
+            listOf("Finale A", "Finale A", "Finale B", "Finale B"),
+            ranks.map { it.team.raceLine?.substringBefore(" ·") },
+        )
+    }
 
     @Test
     fun categoriesBecomeSeparateSectionsInTheConfiguredOrder() {

--- a/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/PerMatchPlacesTest.kt
+++ b/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/PerMatchPlacesTest.kt
@@ -66,7 +66,7 @@ class PerMatchPlacesTest {
     }
 
     @Test
-    fun partienStehenNacheinanderUndNichtVerschraenkt() {
+    fun partienStehenNacheinanderUndZaehlenJedeFuerSich() {
         val entries = CompetitionExecutionService.placesByRatingCategory(zweiFinals())
             .flatMap { it.entries }
 
@@ -74,7 +74,26 @@ class PerMatchPlacesTest {
             listOf("Finale A" to 1, "Finale A" to 2, "Finale B" to 1, "Finale B" to 2),
             entries.map { it.item.matchName to it.item.place },
         )
-        assertEquals(listOf(1, 2, 3, 4), entries.map { it.categoryPlace })
+        // Der Kategorieplatz ist die angezeigte Zahl (Platzierungsansicht, Ergebnis-PDF): jede
+        // Partie hat ihren eigenen Ersten, statt dass Finale B bei 3 weiterzählt.
+        assertEquals(listOf(1, 2, 1, 2), entries.map { it.categoryPlace })
+    }
+
+    @Test
+    fun bootsOhnePartieStehenHinterAllenPartien() {
+        // Ein Boot, das in einer früheren Runde ausgeschieden ist: sein Platz zählt das
+        // Gesamtfeld (hier 5) und trägt keine Partie. Es gehört hinter beide Finals - nicht
+        // wegen der Zahl, sondern weil die Partie-internen Plätze zuerst kommen - und zählt
+        // dort an der Gesamtposition weiter, statt selbst wieder bei 1 anzufangen.
+        val entries = CompetitionExecutionService.placesByRatingCategory(
+            zweiFinals() + TeamPlacement(team(5), place = 5)
+        ).flatMap { it.entries }
+
+        assertEquals(
+            listOf("Finale A", "Finale A", "Finale B", "Finale B", null),
+            entries.map { it.item.matchName },
+        )
+        assertEquals(listOf(1, 2, 1, 2, 5), entries.map { it.categoryPlace })
     }
 
     @Test
@@ -92,8 +111,10 @@ class PerMatchPlacesTest {
         )
 
         assertEquals(listOf("Leichtgewicht", "Offen"), sections.map { it.category?.name })
+        // In jeder Kategorie zählt jede Partie für sich: das beste Boot der Kategorie in seiner
+        // Partie ist dort Kategorie-Erster, auch wenn es die Partie nicht gewonnen hat.
         sections.forEach { section ->
-            assertEquals(listOf(1, 2), section.entries.map { it.categoryPlace })
+            assertEquals(listOf(1, 1), section.entries.map { it.categoryPlace })
         }
     }
 


### PR DESCRIPTION
Folge zu #108: Das Backend vergibt die Plätze je Partie richtig, aber die Anzeigen zählten darüber hinweg.

## Was falsch war

- **Platzierungsansicht und Ergebnis-PDF** zeigen den Kategorieplatz — und der lief durch: Finale B begann bei 3 statt bei 1. Der Partie-Zusatz stand zwar daneben, die Zahl widersprach ihm.
- **Siegerehrungsbogen und Aushang-Ergebnisliste** gruppierten nach dem rohen Platz und machten aus den Siegern zweier Finals einen *geteilten* Platz 1, in Startnummern-Reihenfolge gemischt.
- **Reihenfolge bei gemischten Runden:** In früheren Runden Ausgeschiedene (ohne Partie) sortierten *vor* Finale A, weil die Ordnung fehlende Partien als 0 statt als „hinter allen" las.

## Was jetzt gilt

`RatingCategoryRanking` — die eine Stelle, an der alle Ergebnisanzeigen zählen — kennt die Partie als eigene Dimension:

- Partien stehen nacheinander in Setup-Reihenfolge, **in jeder beginnt die Zählung neu ab 1**, und nur Boote derselben Partie können sich einen Platz teilen.
- Boote ohne Partie stehen hinter allen Partien und zählen an der Gesamtposition weiter (nach A mit 1–2 und B mit 1–2 ist ein Vorrunden-Ausgeschiedener der 5.).
- Auf dem Siegerehrungsbogen bildet (Partie, Platz) die Blöcke: der Podiumsschnitt gilt je Partie, beide Sieger werden geehrt; welche Partie ein Block meint, sagt die Rennzeile seiner Boote.
- Dieselbe Ordnung gilt für die CSV (`TeamPlacement.ordering`).

Ohne Wertung je Partie sind alle Partie-Werte null und **nichts ändert sich** — die bestehenden Zählregel-Tests (Gleichstände, Lücken, Abschnittsreihenfolge) laufen unverändert. Die Urkunden lesen weiter den rohen Platz je Partie und waren schon richtig. Kein Frontend-Anteil: die Zahl kommt fertig vom Backend.

## Geprüft

`./mvnw clean test` gegen den aktuellen `main`: 1114 Tests grün, darunter neu: Neuzählung je Partie, Kategorie-Zählung je Partie, Ausgeschiedene hinter allen Partien, getrennte Podiumsblöcke auf dem Bogen.