### PR TITLE
Nennung der Zeitnahme verweist auf die Ergebnisseite des Rennens

### DIFF
--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/boundary/CompetitionExecutionService.kt
@@ -1383,8 +1383,9 @@ object CompetitionExecutionService {
             }.orDie()
         }
 
-        // Die Ergebnisse dieses Laufs kommen aus RaceClocker - die Nennung steht damit fest.
-        !prepareForNewPlaces(matchId, userId, timing = TimingAttribution.RACECLOCKER)
+        // Die Ergebnisse dieses Laufs kommen aus RaceClocker - die Nennung steht damit fest und
+        // zeigt auf die Ergebnisseite des Rennens, aus dem sie geholt wurden.
+        !prepareForNewPlaces(matchId, userId, timing = TimingAttribution.raceClocker(target.resultsUrl))
 
         val parsed = withResult.map { (registrationId, row) ->
             ParsedTeamResult(

--- a/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TimingAttribution.kt
+++ b/backend/src/main/kotlin/de/lambda9/ready2race/backend/app/competitionExecution/entity/TimingAttribution.kt
@@ -13,11 +13,22 @@ data class TimingAttribution(
 ) {
     companion object {
 
+        const val RACECLOCKER_NAME = "RaceClocker"
+
+        /** Der Rückfall, wenn dem Wettkampf kein Rennen zugeordnet ist - dann gibt es keine Seite. */
+        const val RACECLOCKER_HOME = "https://raceclocker.com"
+
         /**
          * Der Live-Abruf holt seine Ergebnisse direkt aus RaceClocker und kennt keine
-         * Import-Konfiguration, an der eine Nennung gepflegt wäre. Für ihn steht sie hier.
+         * Import-Konfiguration, an der eine Nennung gepflegt wäre. Verlinkt wird die
+         * Ergebnisseite des Rennens, aus dem die Zeiten kommen - dieselbe Adresse, die der Abruf
+         * anfragt. Ein Verweis auf die Startseite ließe den Leser mit der Suche allein, und die
+         * Nennung soll die Zeiten belegen und nicht nur den Anbieter nennen.
          */
-        val RACECLOCKER = TimingAttribution("RaceClocker", "https://raceclocker.com")
+        fun raceClocker(resultsUrl: String?) = TimingAttribution(
+            name = RACECLOCKER_NAME,
+            url = resultsUrl?.takeIf { it.isNotBlank() } ?: RACECLOCKER_HOME,
+        )
 
         /**
          * Die Nennung einer Import-Konfiguration - `null`, solange dort keine gepflegt ist.

--- a/backend/src/main/resources/db/migration/V202608211200__timing_provider_results_url.sql
+++ b/backend/src/main/resources/db/migration/V202608211200__timing_provider_results_url.sql
@@ -1,0 +1,25 @@
+set search_path to ready2race, pg_catalog, public;
+
+-- Die Nennung der Zeitnahme verweist auf die Ergebnisseite des Rennens statt auf die Startseite
+-- des Anbieters (Wunsch vom 21.08.2026).
+--
+-- V202608201200 hat für alle Läufe aus dem RaceClocker-Abruf `https://raceclocker.com` eingetragen
+-- - die Startseite, von der aus der Leser die Regatta selbst suchen müsste. Gemeint ist die
+-- Adresse, aus der die Zeiten tatsächlich geholt werden: `raceclocker_race.results_url` des
+-- Rennens, das am Wettkampf hängt. Neue Ergebnisse schreiben sie ab jetzt selbst mit; hier
+-- kommt der Bestand nach.
+--
+-- Angefasst wird nur, was noch wörtlich auf der Startseite steht. Eine von Hand gepflegte
+-- Nennung aus einer Import-Konfiguration bleibt damit unberührt, auch wenn sie „RaceClocker"
+-- heißt: Wer dort eine eigene Adresse eingetragen hat, meint sie auch so.
+update competition_match cm
+set timing_provider_url = r.results_url
+from competition_setup_match csm
+    join competition_setup_round csr on csm.competition_setup_round = csr.id
+    join competition_properties cp on csr.competition_setup = cp.id
+    join competition c on cp.competition = c.id
+    join raceclocker_race r on c.raceclocker_race = r.id
+where cm.competition_setup_match = csm.id
+  and cm.timing_provider_name = 'RaceClocker'
+  and cm.timing_provider_url = 'https://raceclocker.com'
+  and r.results_url is not null;

--- a/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/raceclocker/TimingProviderResultsUrlMigrationTest.kt
+++ b/backend/src/test/kotlin/de/lambda9/ready2race/backend/app/raceclocker/TimingProviderResultsUrlMigrationTest.kt
@@ -1,0 +1,196 @@
+package de.lambda9.ready2race.backend.app.raceclocker
+
+import org.flywaydb.core.Flyway
+import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Die Migration V202608211200 gegen echte Altdaten: Sie hebt die Nennung der Zeitnahme von der
+ * Startseite des Anbieters auf die Ergebnisseite des Rennens, aus dem die Zeiten kamen.
+ *
+ * Der Bestand ist der eigentliche Punkt. V202608201200 hat für die schon gefahrene Regatta
+ * `https://raceclocker.com` eingetragen; von dort aus müsste der Leser die Regatta selbst suchen.
+ * Zugleich darf die Migration nicht zu weit greifen: Eine von Hand gepflegte Adresse aus einer
+ * Import-Konfiguration bleibt stehen, auch wenn sie „RaceClocker" heißt, und ein Wettkampf ohne
+ * angewähltes Rennen behält seinen Rückfall, statt ohne Verweis dazustehen.
+ *
+ * Wie [RaceClockerSingleRaceMigrationTest] mit eigenem Container: Der übliche Testcontainer
+ * migriert immer bis zum Ende, und über einer leeren Datenbank gäbe es nichts nachzuziehen.
+ */
+class TimingProviderResultsUrlMigrationTest {
+
+    private val eventId = UUID.randomUUID()
+    private val raceId = UUID.randomUUID()
+
+    private val raceResultsUrl = "https://raceclocker.com/0a77d582"
+    private val providerHome = "https://raceclocker.com"
+    private val ownUrl = "https://zeitnahme.example/regatta"
+
+    /** Aus dem Abruf, mit angewähltem Rennen - die Nennung zeigt danach auf dessen Ergebnisseite. */
+    private val pulledMatchId = UUID.randomUUID()
+
+    /** Aus einer Import-Konfiguration mit eigener Adresse - sie bleibt unangetastet. */
+    private val importedMatchId = UUID.randomUUID()
+
+    /** Ohne angewähltes Rennen - es gibt keine Seite, der Rückfall bleibt. */
+    private val raceLessMatchId = UUID.randomUUID()
+
+    @Test
+    fun `hebt die Nennung auf die Ergebnisseite des Rennens und laesst gepflegte Adressen stehen`() {
+        val postgres = PostgreSQLContainer("postgres:17")
+        postgres.start()
+        try {
+            // Bis einschließlich V202608201200 migrieren - der Stand, auf dem die Nennung existiert
+            // und noch auf die Startseite zeigt. Ohne afterMigrate: Das Skript baut die Views des
+            // ENDSTANDS; der zweite, vollständige Lauf unten zieht sie regulär hoch.
+            flyway(postgres).target("202608201200").skipDefaultCallbacks(true).load().migrate()
+
+            connect(postgres).use { seedLegacyState(it) }
+
+            // Jetzt der Rest, insbesondere V202608211200.
+            flyway(postgres).load().migrate()
+
+            connect(postgres).use { conn ->
+                assertEquals(raceResultsUrl, timingProviderUrl(conn, pulledMatchId))
+                assertEquals(ownUrl, timingProviderUrl(conn, importedMatchId))
+                assertEquals(providerHome, timingProviderUrl(conn, raceLessMatchId))
+
+                // Der Name bleibt in allen Fällen, was er war - die Migration fasst nur die Adresse an.
+                assertEquals("RaceClocker", timingProviderName(conn, pulledMatchId))
+                assertEquals("RaceClocker", timingProviderName(conn, importedMatchId))
+            }
+        } finally {
+            postgres.stop()
+        }
+    }
+
+    private fun flyway(postgres: PostgreSQLContainer<*>) = Flyway.configure()
+        .dataSource(postgres.jdbcUrl, postgres.username, postgres.password)
+        .defaultSchema("ready2race")
+
+    private fun connect(postgres: PostgreSQLContainer<*>): Connection =
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+
+    private fun seedLegacyState(conn: Connection) {
+        insertEvent(conn)
+        insertRace(conn)
+
+        val roundWithRace = insertCompetitionWithSetup(conn, race = raceId)
+        val roundWithoutRace = insertCompetitionWithSetup(conn, race = null)
+
+        insertMatch(conn, pulledMatchId, roundWithRace, weighting = 1, provider = "RaceClocker", url = providerHome)
+        insertMatch(conn, importedMatchId, roundWithRace, weighting = 2, provider = "RaceClocker", url = ownUrl)
+        insertMatch(conn, raceLessMatchId, roundWithoutRace, weighting = 1, provider = "RaceClocker", url = providerHome)
+    }
+
+    private fun insertEvent(conn: Connection) {
+        conn.prepareStatement(
+            "insert into ready2race.event (id, name, created_at, updated_at) values (?, 'Testregatta', now(), now())"
+        ).use { stmt ->
+            stmt.setObject(1, eventId)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertRace(conn: Connection) {
+        conn.prepareStatement(
+            "insert into ready2race.raceclocker_race (id, event, name, results_url, position, created_at, updated_at) " +
+                "values (?, ?, 'Kurzstrecke', ?, 1, now(), now())"
+        ).use { stmt ->
+            stmt.setObject(1, raceId)
+            stmt.setObject(2, eventId)
+            stmt.setString(3, raceResultsUrl)
+            stmt.executeUpdate()
+        }
+    }
+
+    /** Wettkampf samt der Kette bis zur Runde, in der die Partien der Läufe hängen. */
+    private fun insertCompetitionWithSetup(conn: Connection, race: UUID?): UUID {
+        val competitionId = UUID.randomUUID()
+        val propertiesId = UUID.randomUUID()
+        val roundId = UUID.randomUUID()
+
+        conn.prepareStatement(
+            "insert into ready2race.competition (id, event, raceclocker_race, created_at, updated_at) " +
+                "values (?, ?, ?, now(), now())"
+        ).use { stmt ->
+            stmt.setObject(1, competitionId)
+            stmt.setObject(2, eventId)
+            stmt.setObject(3, race)
+            stmt.executeUpdate()
+        }
+
+        conn.prepareStatement(
+            "insert into ready2race.competition_properties (id, competition, identifier, name) values (?, ?, '1', 'Testwettkampf')"
+        ).use { stmt ->
+            stmt.setObject(1, propertiesId)
+            stmt.setObject(2, competitionId)
+            stmt.executeUpdate()
+        }
+
+        conn.prepareStatement(
+            "insert into ready2race.competition_setup (competition_properties, created_at, updated_at) values (?, now(), now())"
+        ).use { stmt ->
+            stmt.setObject(1, propertiesId)
+            stmt.executeUpdate()
+        }
+
+        conn.prepareStatement(
+            "insert into ready2race.competition_setup_round " +
+                "(id, competition_setup, name, required, use_default_seeding, places_option) " +
+                "values (?, ?, 'Hauptrunde', true, true, 'ASCENDING')"
+        ).use { stmt ->
+            stmt.setObject(1, roundId)
+            stmt.setObject(2, propertiesId)
+            stmt.executeUpdate()
+        }
+
+        return roundId
+    }
+
+    /**
+     * Die Partie IST der Schlüssel des Laufs (`competition_match.competition_setup_match`), deshalb
+     * legt jeder Lauf hier seine eigene Partie an.
+     */
+    private fun insertMatch(conn: Connection, matchId: UUID, roundId: UUID, weighting: Int, provider: String, url: String) {
+        conn.prepareStatement(
+            "insert into ready2race.competition_setup_match (id, competition_setup_round, weighting, execution_order) " +
+                "values (?, ?, ?, ?)"
+        ).use { stmt ->
+            stmt.setObject(1, matchId)
+            stmt.setObject(2, roundId)
+            stmt.setInt(3, weighting)
+            stmt.setInt(4, weighting)
+            stmt.executeUpdate()
+        }
+
+        conn.prepareStatement(
+            "insert into ready2race.competition_match (competition_setup_match, timing_provider_name, timing_provider_url, created_at, updated_at) " +
+                "values (?, ?, ?, now(), now())"
+        ).use { stmt ->
+            stmt.setObject(1, matchId)
+            stmt.setString(2, provider)
+            stmt.setString(3, url)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun timingProviderUrl(conn: Connection, matchId: UUID) =
+        queryText(conn, "select timing_provider_url from ready2race.competition_match where competition_setup_match = ?", matchId)
+
+    private fun timingProviderName(conn: Connection, matchId: UUID) =
+        queryText(conn, "select timing_provider_name from ready2race.competition_match where competition_setup_match = ?", matchId)
+
+    private fun queryText(conn: Connection, sql: String, id: UUID): String? =
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setObject(1, id)
+            stmt.executeQuery().use { rs ->
+                rs.next()
+                rs.getString(1)
+            }
+        }
+}


### PR DESCRIPTION
Nachtrag zu #107. Der Link hinter „Zeitmessung durch RaceClocker" zeigte auf die Startseite des Anbieters — von dort aus müsste der Leser die Regatta selbst suchen. Verlinkt wird jetzt die **Ergebnisseite des Rennens**, aus dem die Zeiten stammen: dieselbe Adresse, die der Abruf anfragt (`raceclocker_race.results_url` des am Wettkampf angewählten Rennens).

- Der Abruf schreibt die Adresse des angewählten Rennens beim Ergebnis mit. Hat ein Wettkampf kein Rennen, bleibt die Startseite als Rückfall — lieber ein grober Verweis als keiner.
- Die Adresse ist weiterhin ein **Abzug**: Wird das Rennen später umbenannt oder umgehängt, behalten schon veröffentlichte Ergebnisse ihren Verweis.
- Die Nennung aus einer Import-Konfiguration (Datei-Import) bleibt unberührt — dort gilt, was gepflegt ist.

## Migration `V202608211200`

Zieht den Bestand nach, aber nur, was noch **wörtlich** auf der Startseite steht. Eine von Hand gepflegte Adresse bleibt stehen, auch wenn die Konfiguration „RaceClocker" heißt: Wer dort eine eigene Adresse eingetragen hat, meint sie auch so.

## Geprüft

`./mvnw test` (1115 grün). Neu darunter `TimingProviderResultsUrlMigrationTest`: eigener Container, Seed auf dem Stand von `V202608201200`, dann hochmigriert. Er nagelt alle drei Fälle fest — abgerufener Lauf bekommt die Ergebnisseite, gepflegte Adresse bleibt, Wettkampf ohne Rennen behält den Rückfall. Damit ist der Nachtrag diesmal an echten Altdaten belegt und nicht nur am grünen Kompilat.

Unabhängig von #109 (reines Frontend), beide sind einzeln mergebar.